### PR TITLE
Add Penrose transition tuning window steering

### DIFF
--- a/Assets/Editor/ControllerEditor.cs
+++ b/Assets/Editor/ControllerEditor.cs
@@ -53,10 +53,14 @@ public sealed class ControllerEditor : Editor
         DrawRow("Mode", directorStatus.Mode.ToString());
         DrawRow("Decision", directorStatus.Decision.ToString());
         DrawRow("Stage", switcherStatus.StageName);
-        DrawRow("Current", FormatIndexedName(switcherStatus.CurrentEffectIndex, switcherStatus.CurrentEffectName));
-        DrawRow("Source", FormatIndexedName(switcherStatus.SourceEffectIndex, switcherStatus.SourceEffectName));
-        DrawRow("Target", FormatIndexedName(switcherStatus.TargetEffectIndex, switcherStatus.TargetEffectName));
-        DrawRow("Transition", FormatIndexedName(switcherStatus.CurrentTransitionIndex, switcherStatus.CurrentTransitionName));
+        DrawRow("Current Effect", FormatIndexedName(switcherStatus.CurrentEffectIndex, switcherStatus.CurrentEffectName));
+        DrawRow("Next Effect", FormatIndexedName(directorStatus.NextEffectIndex, directorStatus.NextEffectName));
+        DrawRow("Source Effect", FormatIndexedName(switcherStatus.SourceEffectIndex, switcherStatus.SourceEffectName));
+        DrawRow("Target Effect", FormatIndexedName(switcherStatus.TargetEffectIndex, switcherStatus.TargetEffectName));
+        DrawRow("Active Transition", FormatIndexedName(switcherStatus.CurrentTransitionIndex, switcherStatus.CurrentTransitionName));
+        DrawRow("Next Transition", FormatIndexedName(directorStatus.NextTransitionIndex, directorStatus.NextTransitionName));
+        DrawRow("Hold Selected Effect", directorStatus.HoldSelectedEffect ? "On" : "Off");
+        DrawRow("Hold Selected Transition", directorStatus.HoldSelectedTransition ? "On" : "Off");
         DrawRow("Current Beat", FormatBeat(directorStatus.CurrentBeat));
         DrawRow("Last Change", FormatBeat(directorStatus.LastChangeBeat));
         DrawRow("Landing", FormatBeat(directorStatus.TransitionLandingBeat));

--- a/Assets/Editor/PenroseTuningWindow.cs
+++ b/Assets/Editor/PenroseTuningWindow.cs
@@ -3,8 +3,8 @@ using UnityEditor;
 using UnityEngine;
 
 /// <summary>
-/// Standalone authoring window for Penrose runtime tuning. The Transitions tab edits saved Transition Settings;
-/// Play Mode steering is wired in a later slice.
+/// Standalone authoring window for Penrose runtime tuning. The Transitions tab edits saved Transition Settings
+/// and, in Play Mode, steers the Director's staged Next Transition.
 /// </summary>
 public sealed class PenroseTuningWindow : EditorWindow
 {
@@ -18,6 +18,7 @@ public sealed class PenroseTuningWindow : EditorWindow
     private Vector2 settingsScroll;
     private TransitionSettingsAsset selectedAsset;
     private SerializedObject selectedSerializedObject;
+    private bool settingsChangedSinceLastSave;
 
     [MenuItem("Window/Penrose/Tuning")]
     public static void Open()
@@ -31,7 +32,23 @@ public sealed class PenroseTuningWindow : EditorWindow
     private void OnEnable()
     {
         titleContent = new GUIContent("Penrose Tuning");
+        EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+        EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
         ReloadTransitions();
+    }
+
+    private void OnDisable()
+    {
+        EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+        SavePendingSettingsAssets();
+    }
+
+    private void OnInspectorUpdate()
+    {
+        if (Application.isPlaying)
+        {
+            Repaint();
+        }
     }
 
     private void OnGUI()
@@ -73,19 +90,36 @@ public sealed class PenroseTuningWindow : EditorWindow
 
     private void DrawTransitionsTab()
     {
+        TryGetLiveController(out var liveController);
+        if (liveController != null)
+        {
+            SyncSelectedTransitionFromDirector(liveController);
+        }
+
         using (new EditorGUILayout.HorizontalScope())
         {
-            DrawTransitionList();
-            DrawSelectedTransitionSettings();
+            DrawTransitionList(liveController);
+            DrawSelectedTransitionSettings(liveController);
         }
     }
 
-    private void DrawTransitionList()
+    private void DrawTransitionList(Controller liveController)
     {
-        using (new EditorGUILayout.VerticalScope(GUILayout.Width(240f)))
+        using (new EditorGUILayout.VerticalScope(GUILayout.Width(260f)))
         {
             EditorGUILayout.LabelField("Transitions", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Edit Mode settings authoring. Play Mode steering is added in the next slice.", MessageType.None);
+            if (liveController != null && liveController.director != null)
+            {
+                EditorGUILayout.HelpBox("Play Mode: selection mirrors Director Next Transition. Click a Transition to stage it through the Director.", MessageType.None);
+            }
+            else if (Application.isPlaying)
+            {
+                EditorGUILayout.HelpBox("Play Mode is running, but the live Director is not ready yet. Settings authoring still works.", MessageType.Warning);
+            }
+            else
+            {
+                EditorGUILayout.HelpBox("Edit Mode: select a Transition to edit its saved settings asset.", MessageType.None);
+            }
 
             using (var scroll = new EditorGUILayout.ScrollViewScope(transitionListScroll, GUI.skin.box))
             {
@@ -99,9 +133,10 @@ public sealed class PenroseTuningWindow : EditorWindow
                         GUI.backgroundColor = new Color(0.3f, 0.55f, 0.7f);
                     }
 
-                    if (GUILayout.Button(transitionNames[i], EditorStyles.miniButton))
+                    var label = isSelected ? $"▶ {transitionNames[i]}" : transitionNames[i];
+                    if (GUILayout.Button(label, EditorStyles.miniButton))
                     {
-                        SelectTransition(i);
+                        SelectTransition(i, liveController);
                         GUI.FocusControl(null);
                     }
 
@@ -111,10 +146,21 @@ public sealed class PenroseTuningWindow : EditorWindow
         }
     }
 
-    private void DrawSelectedTransitionSettings()
+    private void DrawSelectedTransitionSettings(Controller liveController)
     {
         using (new EditorGUILayout.VerticalScope())
         {
+            if (liveController != null)
+            {
+                DrawPlayModeTransitionSteering(liveController);
+                EditorGUILayout.Space();
+            }
+            else if (Application.isPlaying)
+            {
+                EditorGUILayout.HelpBox("No live Controller is ready yet. The saved settings workflow is still available.", MessageType.Warning);
+                EditorGUILayout.Space();
+            }
+
             if (selectedTransitionIndex < 0 || selectedTransitionIndex >= transitionTypes.Length)
             {
                 EditorGUILayout.HelpBox("Select a Transition to edit its saved settings asset.", MessageType.Info);
@@ -154,6 +200,50 @@ public sealed class PenroseTuningWindow : EditorWindow
                 {
                     selectedSerializedObject.ApplyModifiedProperties();
                     EditorUtility.SetDirty(selectedAsset);
+                    settingsChangedSinceLastSave = true;
+                }
+            }
+        }
+    }
+
+    private void DrawPlayModeTransitionSteering(Controller liveController)
+    {
+        var directorReady = liveController.director != null;
+        var directorStatus = liveController.DirectorStatus;
+        var switcherStatus = liveController.SwitcherStatus;
+
+        EditorGUILayout.LabelField("Play Mode Steering", EditorStyles.boldLabel);
+        using (new EditorGUILayout.VerticalScope(GUI.skin.box))
+        {
+            EditorGUILayout.LabelField("Director Next Transition", FormatCatalogChoice(directorStatus.NextTransitionIndex, directorStatus.NextTransitionName));
+            EditorGUILayout.LabelField("Director Next Effect", FormatCatalogChoice(directorStatus.NextEffectIndex, directorStatus.NextEffectName));
+
+            var activeTransition = !switcherStatus.Ready
+                ? "Not Ready"
+                : switcherStatus.IsTransitioning
+                    ? FormatCatalogChoice(switcherStatus.CurrentTransitionIndex, switcherStatus.CurrentTransitionName)
+                    : "None — Mechanical Switcher is showing an Effect";
+            EditorGUILayout.LabelField("Mechanical Switcher Active Transition", activeTransition);
+            EditorGUILayout.LabelField("Mechanical Switcher Stage", string.IsNullOrEmpty(switcherStatus.StageName) ? "Not Ready" : switcherStatus.StageName);
+            EditorGUILayout.LabelField("Current Effect", FormatCatalogChoice(switcherStatus.CurrentEffectIndex, switcherStatus.CurrentEffectName));
+            if (switcherStatus.IsTransitioning)
+            {
+                EditorGUILayout.LabelField("Transition Target Effect", FormatCatalogChoice(switcherStatus.TargetEffectIndex, switcherStatus.TargetEffectName));
+            }
+
+            using (new EditorGUI.DisabledScope(!directorReady || !IsValidTransitionIndex(selectedTransitionIndex)))
+            {
+                EditorGUI.BeginChangeCheck();
+                var holdSelected = EditorGUILayout.ToggleLeft("Hold Selected Transition", directorStatus.HoldSelectedTransition);
+                if (EditorGUI.EndChangeCheck() && directorReady)
+                {
+                    if (holdSelected)
+                    {
+                        liveController.director.SetNextTransition(selectedTransitionIndex);
+                    }
+
+                    liveController.director.SetHoldSelectedTransition(holdSelected);
+                    Repaint();
                 }
             }
         }
@@ -164,7 +254,7 @@ public sealed class PenroseTuningWindow : EditorWindow
         EditorGUILayout.LabelField("Effects", EditorStyles.boldLabel);
         EditorGUILayout.HelpBox(
             "Effects tuning will follow the same selection and Hold Selected pattern later. " +
-            "This slice only implements Transition Settings authoring.",
+            "This slice implements Transitions settings authoring and Play Mode steering.",
             MessageType.Info);
     }
 
@@ -181,17 +271,88 @@ public sealed class PenroseTuningWindow : EditorWindow
             return;
         }
 
-        selectedTransitionIndex = Mathf.Clamp(selectedTransitionIndex, 0, transitionTypes.Length - 1);
-        SelectTransition(selectedTransitionIndex);
+        SetSelectedTransitionIndex(Mathf.Clamp(selectedTransitionIndex, 0, transitionTypes.Length - 1));
     }
 
-    private void SelectTransition(int index)
+    private void SelectTransition(int index, Controller liveController)
+    {
+        if (liveController != null && liveController.director != null)
+        {
+            liveController.director.SetNextTransition(index);
+        }
+
+        SetSelectedTransitionIndex(index);
+    }
+
+    private void SetSelectedTransitionIndex(int index)
     {
         selectedTransitionIndex = index;
         settingsScroll = Vector2.zero;
         selectedAsset = null;
         selectedSerializedObject = null;
         EnsureSelectedAsset();
+    }
+
+    private void SyncSelectedTransitionFromDirector(Controller liveController)
+    {
+        if (liveController.director == null)
+        {
+            return;
+        }
+
+        var nextTransitionIndex = liveController.DirectorStatus.NextTransitionIndex;
+        if (!IsValidTransitionIndex(nextTransitionIndex) || nextTransitionIndex == selectedTransitionIndex)
+        {
+            return;
+        }
+
+        SetSelectedTransitionIndex(nextTransitionIndex);
+    }
+
+    private static bool TryGetLiveController(out Controller liveController)
+    {
+        liveController = null;
+        if (!Application.isPlaying || !Controller.HasInstance)
+        {
+            return false;
+        }
+
+        liveController = Controller.Instance;
+        return liveController != null;
+    }
+
+    private bool IsValidTransitionIndex(int index)
+    {
+        return index >= 0 && index < transitionTypes.Length;
+    }
+
+    private static string FormatCatalogChoice(int index, string name)
+    {
+        if (index < 0)
+        {
+            return "None";
+        }
+
+        return string.IsNullOrEmpty(name) ? $"#{index}" : $"{name} (#{index})";
+    }
+
+    private void OnPlayModeStateChanged(PlayModeStateChange state)
+    {
+        if (state == PlayModeStateChange.ExitingPlayMode)
+        {
+            SavePendingSettingsAssets();
+        }
+    }
+
+    private void SavePendingSettingsAssets()
+    {
+        if (!settingsChangedSinceLastSave)
+        {
+            return;
+        }
+
+        AssetDatabase.SaveAssets();
+        settingsChangedSinceLastSave = false;
     }
 
     private void EnsureSelectedAsset()
@@ -225,6 +386,7 @@ public sealed class PenroseTuningWindow : EditorWindow
             transitionTypes[selectedTransitionIndex],
             transition.CodeDefaults);
         selectedSerializedObject = new SerializedObject(selectedAsset);
+        settingsChangedSinceLastSave = false;
         Repaint();
     }
 

--- a/Assets/Editor/PenroseTuningWindow.cs
+++ b/Assets/Editor/PenroseTuningWindow.cs
@@ -1,0 +1,241 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Standalone authoring window for Penrose runtime tuning. The Transitions tab edits saved Transition Settings;
+/// Play Mode steering is wired in a later slice.
+/// </summary>
+public sealed class PenroseTuningWindow : EditorWindow
+{
+    private static readonly string[] Tabs = { "Transitions", "Effects" };
+
+    private Type[] transitionTypes = Array.Empty<Type>();
+    private string[] transitionNames = Array.Empty<string>();
+    private int selectedTransitionIndex = -1;
+    private int selectedTab;
+    private Vector2 transitionListScroll;
+    private Vector2 settingsScroll;
+    private TransitionSettingsAsset selectedAsset;
+    private SerializedObject selectedSerializedObject;
+
+    [MenuItem("Window/Penrose/Tuning")]
+    public static void Open()
+    {
+        var window = GetWindow<PenroseTuningWindow>();
+        window.titleContent = new GUIContent("Penrose Tuning");
+        window.minSize = new Vector2(720f, 440f);
+        window.Show();
+    }
+
+    private void OnEnable()
+    {
+        titleContent = new GUIContent("Penrose Tuning");
+        ReloadTransitions();
+    }
+
+    private void OnGUI()
+    {
+        DrawToolbar();
+        selectedTab = GUILayout.Toolbar(selectedTab, Tabs, EditorStyles.toolbarButton);
+
+        EditorGUILayout.Space();
+        switch (selectedTab)
+        {
+            case 0:
+                DrawTransitionsTab();
+                break;
+            case 1:
+                DrawEffectsTab();
+                break;
+        }
+    }
+
+    private void DrawToolbar()
+    {
+        using (new EditorGUILayout.HorizontalScope(EditorStyles.toolbar))
+        {
+            if (GUILayout.Button("Reload", EditorStyles.toolbarButton, GUILayout.Width(64f)))
+            {
+                ReloadTransitions();
+            }
+
+            if (GUILayout.Button("Create Missing Settings", EditorStyles.toolbarButton, GUILayout.Width(150f)))
+            {
+                TransitionSettingsAssetUtility.EnsureCatalogAssets();
+                ReloadTransitions();
+            }
+
+            GUILayout.FlexibleSpace();
+            GUILayout.Label("Window > Penrose > Tuning", EditorStyles.miniLabel);
+        }
+    }
+
+    private void DrawTransitionsTab()
+    {
+        using (new EditorGUILayout.HorizontalScope())
+        {
+            DrawTransitionList();
+            DrawSelectedTransitionSettings();
+        }
+    }
+
+    private void DrawTransitionList()
+    {
+        using (new EditorGUILayout.VerticalScope(GUILayout.Width(240f)))
+        {
+            EditorGUILayout.LabelField("Transitions", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox("Edit Mode settings authoring. Play Mode steering is added in the next slice.", MessageType.None);
+
+            using (var scroll = new EditorGUILayout.ScrollViewScope(transitionListScroll, GUI.skin.box))
+            {
+                transitionListScroll = scroll.scrollPosition;
+                for (var i = 0; i < transitionTypes.Length; i++)
+                {
+                    var isSelected = i == selectedTransitionIndex;
+                    var previousColor = GUI.backgroundColor;
+                    if (isSelected)
+                    {
+                        GUI.backgroundColor = new Color(0.3f, 0.55f, 0.7f);
+                    }
+
+                    if (GUILayout.Button(transitionNames[i], EditorStyles.miniButton))
+                    {
+                        SelectTransition(i);
+                        GUI.FocusControl(null);
+                    }
+
+                    GUI.backgroundColor = previousColor;
+                }
+            }
+        }
+    }
+
+    private void DrawSelectedTransitionSettings()
+    {
+        using (new EditorGUILayout.VerticalScope())
+        {
+            if (selectedTransitionIndex < 0 || selectedTransitionIndex >= transitionTypes.Length)
+            {
+                EditorGUILayout.HelpBox("Select a Transition to edit its saved settings asset.", MessageType.Info);
+                return;
+            }
+
+            EnsureSelectedAsset();
+            if (selectedAsset == null || selectedSerializedObject == null)
+            {
+                EditorGUILayout.HelpBox("Could not create or load the selected Transition Settings asset.", MessageType.Error);
+                return;
+            }
+
+            EditorGUILayout.LabelField(transitionNames[selectedTransitionIndex], EditorStyles.boldLabel);
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                using (new EditorGUI.DisabledScope(true))
+                {
+                    EditorGUILayout.ObjectField("Settings Asset", selectedAsset, typeof(TransitionSettingsAsset), false);
+                }
+
+                if (GUILayout.Button("Restore Defaults", GUILayout.Width(130f)))
+                {
+                    RestoreSelectedDefaults();
+                }
+            }
+
+            EditorGUILayout.Space();
+            using (var scroll = new EditorGUILayout.ScrollViewScope(settingsScroll))
+            {
+                settingsScroll = scroll.scrollPosition;
+                selectedSerializedObject.Update();
+                var settingsProperty = selectedSerializedObject.FindProperty("settings");
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.PropertyField(settingsProperty, includeChildren: true);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    selectedSerializedObject.ApplyModifiedProperties();
+                    EditorUtility.SetDirty(selectedAsset);
+                }
+            }
+        }
+    }
+
+    private void DrawEffectsTab()
+    {
+        EditorGUILayout.LabelField("Effects", EditorStyles.boldLabel);
+        EditorGUILayout.HelpBox(
+            "Effects tuning will follow the same selection and Hold Selected pattern later. " +
+            "This slice only implements Transition Settings authoring.",
+            MessageType.Info);
+    }
+
+    private void ReloadTransitions()
+    {
+        var factory = new Factory<TransitionBase>();
+        transitionTypes = factory.Types;
+        transitionNames = factory.Names;
+        if (transitionTypes.Length == 0)
+        {
+            selectedTransitionIndex = -1;
+            selectedAsset = null;
+            selectedSerializedObject = null;
+            return;
+        }
+
+        selectedTransitionIndex = Mathf.Clamp(selectedTransitionIndex, 0, transitionTypes.Length - 1);
+        SelectTransition(selectedTransitionIndex);
+    }
+
+    private void SelectTransition(int index)
+    {
+        selectedTransitionIndex = index;
+        settingsScroll = Vector2.zero;
+        selectedAsset = null;
+        selectedSerializedObject = null;
+        EnsureSelectedAsset();
+    }
+
+    private void EnsureSelectedAsset()
+    {
+        if (selectedAsset != null && selectedSerializedObject != null)
+        {
+            return;
+        }
+
+        var transition = CreateSelectedTransition();
+        if (transition == null)
+        {
+            return;
+        }
+
+        selectedAsset = TransitionSettingsAssetUtility.EnsureAsset(
+            transitionTypes[selectedTransitionIndex],
+            transition.CodeDefaults);
+        selectedSerializedObject = new SerializedObject(selectedAsset);
+    }
+
+    private void RestoreSelectedDefaults()
+    {
+        var transition = CreateSelectedTransition();
+        if (transition == null)
+        {
+            return;
+        }
+
+        selectedAsset = TransitionSettingsAssetUtility.RestoreDefaults(
+            transitionTypes[selectedTransitionIndex],
+            transition.CodeDefaults);
+        selectedSerializedObject = new SerializedObject(selectedAsset);
+        Repaint();
+    }
+
+    private TransitionBase CreateSelectedTransition()
+    {
+        if (selectedTransitionIndex < 0 || selectedTransitionIndex >= transitionTypes.Length)
+        {
+            return null;
+        }
+
+        var factory = new Factory<TransitionBase>();
+        return factory.Create(transitionTypes[selectedTransitionIndex]);
+    }
+}

--- a/Assets/Editor/PenroseTuningWindow.cs.meta
+++ b/Assets/Editor/PenroseTuningWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 01c7085f0b05d49a0b03da1105807bd1

--- a/Assets/Editor/TransitionSettingsAssetUtility.cs
+++ b/Assets/Editor/TransitionSettingsAssetUtility.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Editor-only creation and restore helpers for per-transition settings assets.
+/// </summary>
+public static class TransitionSettingsAssetUtility
+{
+    public const string DefaultAssetFolder = "Assets/transitions/Resources/TransitionSettings";
+
+    /// <summary>Returns the project asset path for a Transition's settings asset.</summary>
+    public static string AssetPathFor(Type transitionType, string assetFolder = DefaultAssetFolder)
+    {
+        if (transitionType == null)
+        {
+            throw new ArgumentNullException(nameof(transitionType));
+        }
+
+        return $"{assetFolder}/{transitionType.Name}Settings.asset";
+    }
+
+    /// <summary>Creates the settings asset if missing, initialized from Code Defaults.</summary>
+    public static TransitionSettingsAsset EnsureAsset(
+        Type transitionType,
+        TransitionSettings codeDefaults,
+        string assetFolder = DefaultAssetFolder)
+    {
+        if (transitionType == null)
+        {
+            throw new ArgumentNullException(nameof(transitionType));
+        }
+
+        if (codeDefaults == null)
+        {
+            throw new ArgumentNullException(nameof(codeDefaults));
+        }
+
+        EnsureFolder(assetFolder);
+        var assetPath = AssetPathFor(transitionType, assetFolder);
+        var asset = AssetDatabase.LoadAssetAtPath<TransitionSettingsAsset>(assetPath);
+        if (asset != null)
+        {
+            return asset;
+        }
+
+        asset = ScriptableObject.CreateInstance<TransitionSettingsAsset>();
+        asset.Initialize(transitionType.FullName ?? transitionType.Name, codeDefaults);
+        AssetDatabase.CreateAsset(asset, assetPath);
+        EditorUtility.SetDirty(asset);
+        AssetDatabase.SaveAssets();
+        return asset;
+    }
+
+    /// <summary>Restores an existing or newly created settings asset from Code Defaults.</summary>
+    public static TransitionSettingsAsset RestoreDefaults(
+        Type transitionType,
+        TransitionSettings codeDefaults,
+        string assetFolder = DefaultAssetFolder)
+    {
+        var asset = EnsureAsset(transitionType, codeDefaults, assetFolder);
+        Undo.RecordObject(asset, $"Restore {transitionType.Name} Transition Settings Defaults");
+        asset.RestoreDefaults(codeDefaults);
+        EditorUtility.SetDirty(asset);
+        AssetDatabase.SaveAssets();
+        return asset;
+    }
+
+    /// <summary>Creates any missing settings assets for the reflected Transition catalog.</summary>
+    public static IReadOnlyList<TransitionSettingsAsset> EnsureCatalogAssets(string assetFolder = DefaultAssetFolder)
+    {
+        var createdOrExisting = new List<TransitionSettingsAsset>();
+        var factory = new Factory<TransitionBase>();
+        foreach (var transitionType in factory.Types)
+        {
+            var transition = factory.Create(transitionType);
+            if (transition == null)
+            {
+                throw new InvalidOperationException($"Could not instantiate Transition type {transitionType.FullName}.");
+            }
+
+            createdOrExisting.Add(EnsureAsset(transitionType, transition.CodeDefaults, assetFolder));
+        }
+
+        return createdOrExisting;
+    }
+
+    [MenuItem("Window/Penrose/Create Missing Transition Settings")]
+    public static void EnsureCatalogAssetsMenu()
+    {
+        var assets = EnsureCatalogAssets();
+        Debug.Log($"Ensured {assets.Count} Transition Settings assets in {DefaultAssetFolder}.");
+    }
+
+    private static void EnsureFolder(string assetFolder)
+    {
+        if (AssetDatabase.IsValidFolder(assetFolder))
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(assetFolder);
+        AssetDatabase.Refresh();
+    }
+}

--- a/Assets/Editor/TransitionSettingsAssetUtility.cs.meta
+++ b/Assets/Editor/TransitionSettingsAssetUtility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8cea73a00c8934bb3abcf1717b22549d

--- a/Assets/Tests/Editor/DirectorStagingTests.cs
+++ b/Assets/Tests/Editor/DirectorStagingTests.cs
@@ -1,0 +1,161 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+
+public sealed class DirectorStagingTests
+{
+    private GameObject controllerObject;
+    private Controller controller;
+    private Switcher switcher;
+    private Director director;
+
+    [SetUp]
+    public void SetUp()
+    {
+        controllerObject = new GameObject("DirectorStagingTestsController");
+        controller = controllerObject.AddComponent<Controller>();
+        SetControllerSingleton(controller);
+        controller.paletteSource = string.Empty;
+        controller.logDirectorSwitching = false;
+        controller.effectTime = 10f;
+        controller.beatManager = new BeatManager();
+        controller.effects = new EffectBase[] { new TestEffect(), new TestEffect(), new TestEffect() };
+        controller.transitions = new TransitionBase[] { new TestTransition(), new TestTransition(), new TestTransition() };
+        foreach (var transition in controller.transitions)
+        {
+            transition.Init();
+        }
+
+        controller.effectDeck = new[] { 1, 2, 0 };
+        controller.transitionDeck = new[] { 1, 2, 0 };
+        controller.currentTransition = 0;
+        controller.timer = new Timer(controller.effectTime, false);
+
+        switcher = new Switcher(controller, controller.effects, controller.transitions);
+        switcher.SetInitialEffect(0, controller.currentTransition);
+        controller.switcher = switcher;
+
+        director = new Director(
+            controller,
+            switcher,
+            controller.timer,
+            controller.effectDeck,
+            controller.transitionDeck,
+            controller.currentTransition);
+        controller.director = director;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        SetControllerSingleton(null);
+        Object.DestroyImmediate(controllerObject);
+    }
+
+    private static void SetControllerSingleton(Controller instance)
+    {
+        typeof(Singleton<Controller>)
+            .GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic)
+            .SetValue(null, instance);
+    }
+
+    [Test]
+    public void ConstructorStagesNextEffectAndNextTransition()
+    {
+        var status = director.Status;
+
+        Assert.That(status.NextEffectIndex, Is.EqualTo(1));
+        Assert.That(status.NextTransitionIndex, Is.EqualTo(0));
+        Assert.That(status.NextEffectIndex, Is.Not.EqualTo(switcher.CurrentEffectIndex));
+    }
+
+    [Test]
+    public void StandaloneMoveConsumesStagedNextEffectAndNextTransition()
+    {
+        director.SetNextEffect(2);
+        director.SetNextTransition(2);
+
+        director.OnTimerFinished();
+
+        Assert.That(switcher.IsTransitioning, Is.True);
+        Assert.That(switcher.Status.TargetEffectIndex, Is.EqualTo(2));
+        Assert.That(switcher.Status.CurrentTransitionIndex, Is.EqualTo(2));
+        Assert.That(director.Status.NextEffectIndex, Is.EqualTo(2));
+        Assert.That(director.Status.NextTransitionIndex, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void ManualSelectionsAreOneShotWhenHoldSelectedIsOff()
+    {
+        director.SetNextEffect(2);
+        director.SetNextTransition(2);
+
+        director.OnTimerFinished();
+        director.OnTimerFinished();
+
+        Assert.That(switcher.IsTransitioning, Is.False);
+        Assert.That(switcher.CurrentEffectIndex, Is.EqualTo(2));
+        Assert.That(director.Status.NextEffectIndex, Is.Not.EqualTo(2));
+        Assert.That(director.Status.NextTransitionIndex, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void HoldSelectedTransitionKeepsSelectedTransitionStagedAfterCompletion()
+    {
+        director.SetNextTransition(2);
+        director.SetHoldSelectedTransition(true);
+
+        director.OnTimerFinished();
+        director.OnTimerFinished();
+
+        Assert.That(switcher.IsTransitioning, Is.False);
+        Assert.That(director.Status.HoldSelectedTransition, Is.True);
+        Assert.That(director.Status.NextTransitionIndex, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void HoldSelectedEffectKeepsSelectedEffectStagedAfterCompletion()
+    {
+        director.SetNextEffect(2);
+        director.SetHoldSelectedEffect(true);
+
+        director.OnTimerFinished();
+        director.OnTimerFinished();
+
+        Assert.That(switcher.IsTransitioning, Is.False);
+        Assert.That(director.Status.HoldSelectedEffect, Is.True);
+        Assert.That(director.Status.NextEffectIndex, Is.EqualTo(2));
+    }
+
+    private sealed class TestEffect : EffectBase
+    {
+        public override string DebugText() => string.Empty;
+
+        public override void OnStart()
+        {
+        }
+
+        public override void OnEnd()
+        {
+        }
+
+        public override void Draw()
+        {
+        }
+    }
+
+    private sealed class TestTransition : TransitionBase
+    {
+        public override void OnStart()
+        {
+        }
+
+        public override void OnEnd()
+        {
+        }
+
+        public override void Draw()
+        {
+        }
+    }
+}

--- a/Assets/Tests/Editor/DirectorStagingTests.cs.meta
+++ b/Assets/Tests/Editor/DirectorStagingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1ff9935135ac4d82818c1e1c3d986941

--- a/Assets/Tests/Editor/TransitionSettingsTests.cs
+++ b/Assets/Tests/Editor/TransitionSettingsTests.cs
@@ -1,0 +1,158 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+public sealed class TransitionSettingsTests
+{
+    private const string TempAssetFolder = "Assets/Tests/Editor/TempTransitionSettings";
+    private const string TempResourcesRoot = "Assets/Tests/Editor/TempTransitionSettingsResources";
+    private const string TempResourcesFolder = TempResourcesRoot + "/Resources/TransitionSettings";
+
+    [SetUp]
+    public void SetUp()
+    {
+        CleanupTempAssets();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        CleanupTempAssets();
+    }
+
+    [Test]
+    public void CodeDefaultsCoverConcreteTransitionRepertoiresAndAuthoringDefaults()
+    {
+        AssertSettings(new Fade().CodeDefaults, global::Repertoire.None, 4, 0, TransitionShape.Blend, TransitionIntensity.Subtle, 4f, 0.5f);
+        AssertSettings(new RGBFade().CodeDefaults, global::Repertoire.RespondsToEnergy, 4, 4, TransitionShape.ChannelBlend, TransitionIntensity.Medium, 4f, 0.5f);
+        AssertSettings(new DirectionalWipe().CodeDefaults, global::Repertoire.RespondsToEnergy, 4, 4, TransitionShape.DirectionalWipe, TransitionIntensity.Medium, 4f, 0.5f);
+        AssertSettings(new IndexWipe().CodeDefaults, global::Repertoire.None, 4, 0, TransitionShape.IndexWipe, TransitionIntensity.Medium, 4f, 0.5f);
+        AssertSettings(new FizzleTransition().CodeDefaults, global::Repertoire.HandlesDrop, 4, 4, TransitionShape.Dissolve, TransitionIntensity.High, 4f, 0.5f);
+        AssertSettings(new IrisTransition().CodeDefaults, global::Repertoire.HandlesDrop, 4, 4, TransitionShape.Iris, TransitionIntensity.High, 4f, 0.5f);
+        AssertSettings(new NoiseTransition().CodeDefaults, global::Repertoire.HandlesDrop | global::Repertoire.RespondsToEnergy, 4, 4, TransitionShape.Noise, TransitionIntensity.High, 4f, 0.5f);
+
+        var directional = new DirectionalWipe().CodeDefaults;
+        Assert.That(directional.DirectionalReactiveEdgeWidth, Is.EqualTo(0.055f));
+        Assert.That(directional.DirectionalLowBandResponseGain, Is.EqualTo(2f));
+
+        var noise = new NoiseTransition().CodeDefaults;
+        Assert.That(noise.NoiseScale, Is.EqualTo(0.07f));
+        Assert.That(noise.NoiseProgressRange, Is.EqualTo(1.1f));
+        Assert.That(noise.NoiseBorderWidth, Is.EqualTo(0.1f));
+    }
+
+    [Test]
+    public void EnsureCatalogAssetsCreatesOneSettingsAssetPerRuntimeTransition()
+    {
+        var assets = TransitionSettingsAssetUtility.EnsureCatalogAssets(TempAssetFolder);
+        var factory = new Factory<TransitionBase>();
+
+        Assert.That(assets.Count, Is.EqualTo(factory.Count));
+        foreach (var transitionType in factory.Types)
+        {
+            var assetPath = TransitionSettingsAssetUtility.AssetPathFor(transitionType, TempAssetFolder);
+            var asset = AssetDatabase.LoadAssetAtPath<TransitionSettingsAsset>(assetPath);
+            Assert.That(asset, Is.Not.Null, transitionType.Name);
+            Assert.That(asset.TransitionTypeName, Is.EqualTo(transitionType.FullName));
+        }
+    }
+
+    [Test]
+    public void RestoreDefaultsCopiesCompleteCodeDefaultsBackIntoSettingsAsset()
+    {
+        var defaults = new DirectionalWipe().CodeDefaults;
+        var asset = TransitionSettingsAssetUtility.EnsureAsset(typeof(DirectionalWipe), defaults, TempAssetFolder);
+        asset.Settings.DefaultDurationSeconds = 12f;
+        asset.Settings.ExternalBlendDefaultProgress = 0.25f;
+        asset.Settings.DirectionalReactiveEdgeWidth = 0.25f;
+        asset.Settings.DirectionalLowBandResponseGain = 9f;
+
+        TransitionSettingsAssetUtility.RestoreDefaults(typeof(DirectionalWipe), defaults, TempAssetFolder);
+
+        Assert.That(asset.Settings.DefaultDurationSeconds, Is.EqualTo(defaults.DefaultDurationSeconds));
+        Assert.That(asset.Settings.ExternalBlendDefaultProgress, Is.EqualTo(defaults.ExternalBlendDefaultProgress));
+        Assert.That(asset.Settings.DirectionalReactiveEdgeWidth, Is.EqualTo(defaults.DirectionalReactiveEdgeWidth));
+        Assert.That(asset.Settings.DirectionalLowBandResponseGain, Is.EqualTo(defaults.DirectionalLowBandResponseGain));
+    }
+
+    [Test]
+    public void RepertoireReadsSavedResourcesSettingsWhenAssetExists()
+    {
+        var defaults = new TestSettingsTransition().CodeDefaults;
+        var asset = TransitionSettingsAssetUtility.EnsureAsset(typeof(TestSettingsTransition), defaults, TempResourcesFolder);
+        asset.Settings.DefaultDurationSeconds = 9f;
+        asset.Settings.RunwayBeats = 3;
+        asset.Settings.TailBeats = 2;
+        EditorUtility.SetDirty(asset);
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+
+        var repertoire = new TestSettingsTransition().Repertoire;
+
+        Assert.That(repertoire.DefaultDurationSeconds, Is.EqualTo(9f));
+        Assert.That(repertoire.RunwayBeats, Is.EqualTo(3));
+        Assert.That(repertoire.TailBeats, Is.EqualTo(2));
+    }
+
+    private static void AssertSettings(
+        TransitionSettings actual,
+        global::Repertoire tags,
+        int runwayBeats,
+        int tailBeats,
+        TransitionShape shape,
+        TransitionIntensity intensity,
+        float defaultDurationSeconds,
+        float externalBlendDefaultProgress)
+    {
+        Assert.That(actual.Tags, Is.EqualTo(tags));
+        Assert.That(actual.RunwayBeats, Is.EqualTo(runwayBeats));
+        Assert.That(actual.TailBeats, Is.EqualTo(tailBeats));
+        Assert.That(actual.Shape, Is.EqualTo(shape));
+        Assert.That(actual.Intensity, Is.EqualTo(intensity));
+        Assert.That(actual.DefaultDurationSeconds, Is.EqualTo(defaultDurationSeconds));
+        Assert.That(actual.ExternalBlendDefaultProgress, Is.EqualTo(externalBlendDefaultProgress));
+    }
+
+    private static void CleanupTempAssets()
+    {
+        if (AssetDatabase.IsValidFolder(TempAssetFolder))
+        {
+            AssetDatabase.DeleteAsset(TempAssetFolder);
+        }
+
+        if (AssetDatabase.IsValidFolder(TempResourcesRoot))
+        {
+            AssetDatabase.DeleteAsset(TempResourcesRoot);
+        }
+
+        AssetDatabase.Refresh();
+    }
+
+    private sealed class TestSettingsTransition : TransitionBase
+    {
+        protected override TransitionSettings BuildCodeDefaults()
+        {
+            return new TransitionSettings
+            {
+                Tags = global::Repertoire.HandlesDrop,
+                RunwayBeats = 1,
+                TailBeats = 0,
+                Shape = TransitionShape.Blend,
+                Intensity = TransitionIntensity.Subtle,
+                DefaultDurationSeconds = 1f,
+            };
+        }
+
+        public override void OnStart()
+        {
+        }
+
+        public override void OnEnd()
+        {
+        }
+
+        public override void Draw()
+        {
+        }
+    }
+}

--- a/Assets/Tests/Editor/TransitionSettingsTests.cs.meta
+++ b/Assets/Tests/Editor/TransitionSettingsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 821a5aedca4a44254b4855e2d54efa10

--- a/Assets/core/Controller.cs
+++ b/Assets/core/Controller.cs
@@ -1195,6 +1195,7 @@ public class Controller : Singleton<Controller>
         }
 
         var builder = new StringBuilder();
+        AppendIfNotEmpty(builder, FormatNextMove(directorStatus));
         if (directorStatus.IsSyncedMode)
         {
             AppendIfNotEmpty(builder, directorStatus.PhaseAnchorConfidence.ToString());
@@ -1241,6 +1242,18 @@ public class Controller : Singleton<Controller>
         }
 
         return status.StageName;
+    }
+
+    private static string FormatNextMove(DirectorStatus status)
+    {
+        if (status.NextEffectIndex < 0 && status.NextTransitionIndex < 0)
+        {
+            return string.Empty;
+        }
+
+        var nextEffect = status.NextEffectIndex >= 0 ? status.NextEffectName : "—";
+        var nextTransition = status.NextTransitionIndex >= 0 ? status.NextTransitionName : "—";
+        return $"next {nextEffect} via {nextTransition}";
     }
 
     private static string FormatPhasePosition(DirectorStatus status)

--- a/Assets/core/Director.cs
+++ b/Assets/core/Director.cs
@@ -42,7 +42,13 @@ public readonly struct DirectorStatus
         -1,
         -1,
         -1,
-        0f);
+        0f,
+        -1,
+        string.Empty,
+        -1,
+        string.Empty,
+        false,
+        false);
 
     public readonly DirectorMode Mode;
     public readonly DirectorDecision Decision;
@@ -56,6 +62,12 @@ public readonly struct DirectorStatus
     public readonly int BeatsUntilLanding;
     public readonly int BeatsUntilCadenceReady;
     public readonly float TransitionProgress;
+    public readonly int NextEffectIndex;
+    public readonly string NextEffectName;
+    public readonly int NextTransitionIndex;
+    public readonly string NextTransitionName;
+    public readonly bool HoldSelectedEffect;
+    public readonly bool HoldSelectedTransition;
 
     public DirectorStatus(
         DirectorMode mode,
@@ -70,7 +82,13 @@ public readonly struct DirectorStatus
         int currentBeat,
         int beatsUntilLanding,
         int beatsUntilCadenceReady,
-        float transitionProgress)
+        float transitionProgress,
+        int nextEffectIndex,
+        string nextEffectName,
+        int nextTransitionIndex,
+        string nextTransitionName,
+        bool holdSelectedEffect,
+        bool holdSelectedTransition)
     {
         Mode = mode;
         Decision = decision;
@@ -85,6 +103,12 @@ public readonly struct DirectorStatus
         BeatsUntilLanding = beatsUntilLanding;
         BeatsUntilCadenceReady = beatsUntilCadenceReady;
         TransitionProgress = transitionProgress;
+        NextEffectIndex = nextEffectIndex;
+        NextEffectName = nextEffectName ?? string.Empty;
+        NextTransitionIndex = nextTransitionIndex;
+        NextTransitionName = nextTransitionName ?? string.Empty;
+        HoldSelectedEffect = holdSelectedEffect;
+        HoldSelectedTransition = holdSelectedTransition;
     }
 
     /// <summary>Current live beat observed by the Director, or -1 outside Synced Mode.</summary>
@@ -106,7 +130,10 @@ public sealed class Director
     private readonly int[] effectDeck;
     private readonly int[] transitionDeck;
 
+    private int nextEffectIndex = -1;
     private int nextTransitionIndex;
+    private bool holdSelectedEffect;
+    private bool holdSelectedTransition;
     private int lastSyncedBeat = -1;
     private int lastChangeBeat = int.MinValue;
     private int lastCueBeat = -1;
@@ -147,6 +174,49 @@ public sealed class Director
     /// <summary>Current read-only sequencing snapshot for runtime HUDs and inspector diagnostics.</summary>
     public DirectorStatus Status => BuildStatus();
 
+    /// <summary>Index of the Effect staged for the next A-to-B move.</summary>
+    public int NextEffectIndex => nextEffectIndex;
+
+    /// <summary>Index of the Transition staged for the next A-to-B move.</summary>
+    public int NextTransitionIndex => nextTransitionIndex;
+
+    /// <summary>Whether the staged Effect should be kept after each completed move.</summary>
+    public bool HoldSelectedEffect => holdSelectedEffect;
+
+    /// <summary>Whether the staged Transition should be kept after each completed move.</summary>
+    public bool HoldSelectedTransition => holdSelectedTransition;
+
+    /// <summary>Stages the Effect that the next A-to-B move should target.</summary>
+    public void SetNextEffect(int effectIndex)
+    {
+        ValidateEffectIndex(effectIndex);
+        nextEffectIndex = effectIndex;
+        Trace($"NEXT_EFFECT_SET nextEffect={FormatEffect(nextEffectIndex)} hold={holdSelectedEffect}");
+    }
+
+    /// <summary>Stages the Transition that the next A-to-B move should use.</summary>
+    public void SetNextTransition(int transitionIndex)
+    {
+        ValidateTransitionIndex(transitionIndex);
+        nextTransitionIndex = transitionIndex;
+        controller.currentTransition = nextTransitionIndex;
+        Trace($"NEXT_TRANSITION_SET nextTransition={FormatTransition(nextTransitionIndex)} hold={holdSelectedTransition}");
+    }
+
+    /// <summary>When enabled, the currently staged Effect is staged again after each completed move.</summary>
+    public void SetHoldSelectedEffect(bool hold)
+    {
+        holdSelectedEffect = hold;
+        Trace($"NEXT_EFFECT_HOLD_SET hold={holdSelectedEffect} nextEffect={FormatEffect(nextEffectIndex)}");
+    }
+
+    /// <summary>When enabled, the currently staged Transition is staged again after each completed move.</summary>
+    public void SetHoldSelectedTransition(bool hold)
+    {
+        holdSelectedTransition = hold;
+        Trace($"NEXT_TRANSITION_HOLD_SET hold={holdSelectedTransition} nextTransition={FormatTransition(nextTransitionIndex)}");
+    }
+
     public Director(
         Controller controller,
         Switcher switcher,
@@ -155,12 +225,18 @@ public sealed class Director
         int[] transitionDeck,
         int initialTransitionIndex)
     {
-        this.controller = controller ?? throw new ArgumentNullException(nameof(controller));
+        if (controller == null)
+        {
+            throw new ArgumentNullException(nameof(controller));
+        }
+
+        this.controller = controller;
         this.switcher = switcher ?? throw new ArgumentNullException(nameof(switcher));
         this.standaloneTimer = standaloneTimer ?? throw new ArgumentNullException(nameof(standaloneTimer));
         this.effectDeck = effectDeck ?? throw new ArgumentNullException(nameof(effectDeck));
         this.transitionDeck = transitionDeck ?? throw new ArgumentNullException(nameof(transitionDeck));
-        nextTransitionIndex = initialTransitionIndex;
+        SetNextTransition(initialTransitionIndex);
+        StageNextEffect(Repertoire.None);
     }
 
     /// <summary>Advances the Director's current cadence clock or live musical scheduling.</summary>
@@ -196,6 +272,7 @@ public sealed class Director
         TransitionProgress = 0f;
         standaloneTimer.Set(durationSeconds);
         standaloneTimer.Reset();
+        StageNextChoices(Repertoire.None);
     }
 
     /// <summary>
@@ -254,7 +331,13 @@ public sealed class Director
             currentBeat,
             beatsUntilLanding,
             beatsUntilCadenceReady,
-            TransitionProgress);
+            TransitionProgress,
+            nextEffectIndex,
+            EffectName(nextEffectIndex),
+            nextTransitionIndex,
+            TransitionName(nextTransitionIndex),
+            holdSelectedEffect,
+            holdSelectedTransition);
     }
 
     private DirectorDecision ResolveDecision(
@@ -500,6 +583,9 @@ public sealed class Director
         }
 
         var transitionIndex = nextTransitionIndex;
+        var targetEffectIndex = nextEffectIndex;
+        ValidateTransitionIndex(transitionIndex);
+        ValidateEffectIndex(targetEffectIndex);
         var repertoire = controller.transitions[transitionIndex].Repertoire;
         var lastCue = lastCueBeat >= 0 ? (int?)lastCueBeat : null;
         var previousImpactBeat = lastChangeBeat == int.MinValue ? (int?)null : lastChangeBeat;
@@ -524,8 +610,8 @@ public sealed class Director
         }
 
         var preferredRepertoire = PreferredRepertoireForLanding(cueDecision.BeatsUntilImpact);
-        Trace($"SYNC_CUE beat={beat} start={cueDecision.BeatPlan.StartBeat} impact={cueDecision.BeatPlan.ImpactBeat} runway={repertoire.RunwayBeats} tail={repertoire.TailBeats} lateBy={Math.Max(0, beat - cueDecision.BeatPlan.StartBeat)} preferred={preferredRepertoire}");
-        StartSyncedTransition(transitionIndex, cueDecision.BeatPlan, repertoire, preferredRepertoire);
+        Trace($"SYNC_CUE beat={beat} start={cueDecision.BeatPlan.StartBeat} impact={cueDecision.BeatPlan.ImpactBeat} runway={repertoire.RunwayBeats} tail={repertoire.TailBeats} lateBy={Math.Max(0, beat - cueDecision.BeatPlan.StartBeat)} preferred={preferredRepertoire} transition={FormatTransition(transitionIndex)} target={FormatEffect(targetEffectIndex)}");
+        StartSyncedTransition(transitionIndex, targetEffectIndex, cueDecision.BeatPlan, repertoire, preferredRepertoire);
     }
 
     private Repertoire PreferredRepertoireForLanding(int beatsUntilLanding)
@@ -537,11 +623,11 @@ public sealed class Director
 
     private void StartSyncedTransition(
         int transitionIndex,
+        int targetEffectIndex,
         TransitionBeatPlan beatPlan,
         TransitionRepertoire repertoire,
         Repertoire preferredRepertoire)
     {
-        var targetEffectIndex = PullEffect(preferredRepertoire);
         switcher.StartTransition(targetEffectIndex, transitionIndex);
         controller.currentTransition = transitionIndex;
 
@@ -586,11 +672,10 @@ public sealed class Director
             Trace($"SYNC_TRANSITION_COMPLETE_REQUEST beat={beat} previousBeat={FormatBeat(previousBeat)} rewound={beatRewoundToNewPass} impact={update.ImpactBeat} plannedImpact={transitionPlan.ImpactBeat} complete={transitionPlan.CompleteBeat} progress={TransitionProgress:0.###} target={FormatEffect(switcher.TransitionTargetEffectIndex)} transition={FormatTransition(switcher.CurrentTransitionIndex)}");
             switcher.CompleteTransition();
             MarkChangedOnBeat(update.ImpactBeat);
-            nextTransitionIndex = PullCard(transitionDeck);
-            controller.currentTransition = nextTransitionIndex;
+            StageNextChoices(Repertoire.None);
             transitionPlan = default;
             TransitionProgress = 0f;
-            Trace($"SYNC_TRANSITION_COMPLETE_DONE beat={beat} rewound={beatRewoundToNewPass} current={FormatEffect(switcher.CurrentEffectIndex)} lastChange={FormatBeat(lastChangeBeat)} nextTransition={FormatTransition(nextTransitionIndex)}");
+            Trace($"SYNC_TRANSITION_COMPLETE_DONE beat={beat} rewound={beatRewoundToNewPass} current={FormatEffect(switcher.CurrentEffectIndex)} lastChange={FormatBeat(lastChangeBeat)} nextEffect={FormatEffect(nextEffectIndex)} nextTransition={FormatTransition(nextTransitionIndex)}");
             return;
         }
 
@@ -735,22 +820,91 @@ public sealed class Director
             standaloneTimer.Set(controller.effectTime);
             standaloneTimer.Reset();
             TransitionProgress = 0f;
-            nextTransitionIndex = PullCard(transitionDeck);
-            controller.currentTransition = nextTransitionIndex;
-            Trace($"STANDALONE_TRANSITION_COMPLETE_DONE current={FormatEffect(switcher.CurrentEffectIndex)} nextTransition={FormatTransition(nextTransitionIndex)}");
+            StageNextChoices(Repertoire.None);
+            Trace($"STANDALONE_TRANSITION_COMPLETE_DONE current={FormatEffect(switcher.CurrentEffectIndex)} nextEffect={FormatEffect(nextEffectIndex)} nextTransition={FormatTransition(nextTransitionIndex)}");
             return;
         }
 
         var transitionIndex = nextTransitionIndex;
+        var targetEffectIndex = nextEffectIndex;
+        ValidateTransitionIndex(transitionIndex);
+        ValidateEffectIndex(targetEffectIndex);
         var transitionRepertoire = controller.transitions[transitionIndex].Repertoire;
         var transitionDurationSeconds = transitionRepertoire.DefaultDurationSeconds;
-        var targetEffectIndex = PullEffect(Repertoire.None);
         Trace($"STANDALONE_TRANSITION_START transition={FormatTransition(transitionIndex)} target={FormatEffect(targetEffectIndex)} durationSeconds={transitionDurationSeconds:0.###}");
         switcher.StartTransition(targetEffectIndex, transitionIndex);
         controller.currentTransition = transitionIndex;
         standaloneTimer.Set(transitionDurationSeconds);
         standaloneTimer.Reset();
         TransitionProgress = 0f;
+    }
+
+    private void StageNextChoices(Repertoire preferredRepertoire)
+    {
+        StageNextEffect(preferredRepertoire);
+        StageNextTransition();
+    }
+
+    private void StageNextEffect(Repertoire preferredRepertoire)
+    {
+        if (holdSelectedEffect)
+        {
+            Trace($"NEXT_EFFECT_HELD nextEffect={FormatEffect(nextEffectIndex)}");
+            return;
+        }
+
+        nextEffectIndex = PullEffect(preferredRepertoire);
+        Trace($"NEXT_EFFECT_STAGED nextEffect={FormatEffect(nextEffectIndex)} preferred={preferredRepertoire}");
+    }
+
+    private void StageNextTransition()
+    {
+        if (holdSelectedTransition)
+        {
+            controller.currentTransition = nextTransitionIndex;
+            Trace($"NEXT_TRANSITION_HELD nextTransition={FormatTransition(nextTransitionIndex)}");
+            return;
+        }
+
+        nextTransitionIndex = PullCard(transitionDeck);
+        controller.currentTransition = nextTransitionIndex;
+        Trace($"NEXT_TRANSITION_STAGED nextTransition={FormatTransition(nextTransitionIndex)}");
+    }
+
+    private bool IsValidEffectIndex(int effectIndex)
+    {
+        return controller.effects != null && effectIndex >= 0 && effectIndex < controller.effects.Length;
+    }
+
+    private bool IsValidTransitionIndex(int transitionIndex)
+    {
+        return controller.transitions != null && transitionIndex >= 0 && transitionIndex < controller.transitions.Length;
+    }
+
+    private void ValidateEffectIndex(int effectIndex)
+    {
+        if (!IsValidEffectIndex(effectIndex))
+        {
+            throw new ArgumentOutOfRangeException(nameof(effectIndex), effectIndex, "Effect index is outside the runtime catalog.");
+        }
+    }
+
+    private void ValidateTransitionIndex(int transitionIndex)
+    {
+        if (!IsValidTransitionIndex(transitionIndex))
+        {
+            throw new ArgumentOutOfRangeException(nameof(transitionIndex), transitionIndex, "Transition index is outside the runtime catalog.");
+        }
+    }
+
+    private string EffectName(int effectIndex)
+    {
+        return IsValidEffectIndex(effectIndex) ? controller.effects[effectIndex].Name : string.Empty;
+    }
+
+    private string TransitionName(int transitionIndex)
+    {
+        return IsValidTransitionIndex(transitionIndex) ? controller.transitions[transitionIndex].Name : string.Empty;
     }
 
     private int PullEffect(Repertoire preferredRepertoire)

--- a/Assets/core/TransitionBase.cs
+++ b/Assets/core/TransitionBase.cs
@@ -27,10 +27,25 @@ public abstract class TransitionBase
     public string Name => GetType().ToString();
 
     /// <summary>
-    /// Musical-structure timing and event behavior this transition advertises to the Director.
-    /// Transition subclasses override this when their A-to-B motion has a specific impact point or musical role.
+    /// Code-authored baseline used when no saved Transition Settings asset exists and when restoring defaults.
     /// </summary>
-    public virtual TransitionRepertoire Repertoire => TransitionRepertoire.Default;
+    public TransitionSettings CodeDefaults => BuildCodeDefaults();
+
+    /// <summary>
+    /// Saved settings when present, otherwise this Transition's Code Defaults. This is read live so Play Mode edits affect future decisions.
+    /// </summary>
+    protected TransitionSettings EffectiveSettings => TransitionSettingsProvider.Resolve(GetType(), CodeDefaults);
+
+    /// <summary>
+    /// Musical-structure timing and event behavior this transition advertises to the Director.
+    /// </summary>
+    public virtual TransitionRepertoire Repertoire => EffectiveSettings.ToRepertoire();
+
+    /// <summary>Builds this Transition's code-authored settings baseline.</summary>
+    protected virtual TransitionSettings BuildCodeDefaults()
+    {
+        return TransitionSettings.FromRepertoire(TransitionRepertoire.Default);
+    }
 
     private int a;
     private int b;

--- a/Assets/core/TransitionSettings.cs
+++ b/Assets/core/TransitionSettings.cs
@@ -1,0 +1,104 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Saved authoring values for a Transition. Code Defaults create and restore this data;
+/// runtime reads the saved asset when present and falls back to Code Defaults otherwise.
+/// </summary>
+[Serializable]
+public sealed class TransitionSettings
+{
+    [Header("Transition Repertoire")]
+    public Repertoire Tags = Repertoire.None;
+    [Min(1)] public int RunwayBeats = 4;
+    [Min(0)] public int TailBeats;
+    public TransitionShape Shape = TransitionShape.Blend;
+    public TransitionIntensity Intensity = TransitionIntensity.Subtle;
+    [Min(0.01f)] public float DefaultDurationSeconds = 4f;
+
+    [Header("External Blend Defaults")]
+    [Range(0f, 1f)] public float ExternalBlendDefaultProgress = 0.5f;
+    public float ExternalBlendDefaultAngleRadians;
+    [Range(0f, 1f)] public float ExternalBlendDefaultDirection;
+    [Range(0f, 1f)] public float ExternalBlendDefaultBorderHue;
+
+    [Header("Directional Wipe Visual Defaults")]
+    [Min(0.001f)] public float DirectionalReactiveEdgeWidth = 0.055f;
+    [Min(0f)] public float DirectionalBaseEdgeBrightnessBoost = 0.15f;
+    [Min(0f)] public float DirectionalLowBandResponseGain = 2f;
+    [Min(0f)] public float DirectionalMaxLowBandBrightnessBoost = 0.85f;
+    [Min(0f)] public float DirectionalBaseEdgeBrightnessLift = 0.025f;
+    [Min(0f)] public float DirectionalMaxLowBandBrightnessLift = 0.14f;
+
+    [Header("Noise Visual Defaults")]
+    [Min(0.001f)] public float NoiseScale = 0.07f;
+    [Min(0f)] public float NoiseProgressRange = 1.1f;
+    [Min(0f)] public float NoiseBorderWidth = 0.1f;
+
+    /// <summary>Builds the Director-facing repertoire contract from the saved authoring values.</summary>
+    public TransitionRepertoire ToRepertoire()
+    {
+        return TransitionRepertoire.FromRunwayAndTail(
+            Tags,
+            RunwayBeats,
+            TailBeats,
+            Shape,
+            Intensity,
+            DefaultDurationSeconds);
+    }
+
+    /// <summary>Creates settings initialized from an existing repertoire contract.</summary>
+    public static TransitionSettings FromRepertoire(TransitionRepertoire repertoire)
+    {
+        var settings = new TransitionSettings();
+        settings.CopyRepertoireFrom(repertoire);
+        return settings;
+    }
+
+    /// <summary>Copies all saved authoring values from another settings object.</summary>
+    public void CopyFrom(TransitionSettings source)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        Tags = source.Tags;
+        RunwayBeats = source.RunwayBeats;
+        TailBeats = source.TailBeats;
+        Shape = source.Shape;
+        Intensity = source.Intensity;
+        DefaultDurationSeconds = source.DefaultDurationSeconds;
+        ExternalBlendDefaultProgress = source.ExternalBlendDefaultProgress;
+        ExternalBlendDefaultAngleRadians = source.ExternalBlendDefaultAngleRadians;
+        ExternalBlendDefaultDirection = source.ExternalBlendDefaultDirection;
+        ExternalBlendDefaultBorderHue = source.ExternalBlendDefaultBorderHue;
+        DirectionalReactiveEdgeWidth = source.DirectionalReactiveEdgeWidth;
+        DirectionalBaseEdgeBrightnessBoost = source.DirectionalBaseEdgeBrightnessBoost;
+        DirectionalLowBandResponseGain = source.DirectionalLowBandResponseGain;
+        DirectionalMaxLowBandBrightnessBoost = source.DirectionalMaxLowBandBrightnessBoost;
+        DirectionalBaseEdgeBrightnessLift = source.DirectionalBaseEdgeBrightnessLift;
+        DirectionalMaxLowBandBrightnessLift = source.DirectionalMaxLowBandBrightnessLift;
+        NoiseScale = source.NoiseScale;
+        NoiseProgressRange = source.NoiseProgressRange;
+        NoiseBorderWidth = source.NoiseBorderWidth;
+    }
+
+    /// <summary>Returns an independent copy so callers can mutate without changing the source.</summary>
+    public TransitionSettings Clone()
+    {
+        var clone = new TransitionSettings();
+        clone.CopyFrom(this);
+        return clone;
+    }
+
+    private void CopyRepertoireFrom(TransitionRepertoire repertoire)
+    {
+        Tags = repertoire.Tags;
+        RunwayBeats = repertoire.RunwayBeats;
+        TailBeats = repertoire.TailBeats;
+        Shape = repertoire.Shape;
+        Intensity = repertoire.Intensity;
+        DefaultDurationSeconds = repertoire.DefaultDurationSeconds;
+    }
+}

--- a/Assets/core/TransitionSettings.cs.meta
+++ b/Assets/core/TransitionSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3b71c9272d13e48a696202e0de0c6887

--- a/Assets/core/TransitionSettingsAsset.cs
+++ b/Assets/core/TransitionSettingsAsset.cs
@@ -1,0 +1,36 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Persistent Unity asset containing the editable settings copy for one Transition type.
+/// </summary>
+[CreateAssetMenu(fileName = "TransitionSettings", menuName = "Penrose/Transition Settings")]
+public sealed class TransitionSettingsAsset : ScriptableObject
+{
+    [SerializeField] private string transitionTypeName = string.Empty;
+    [SerializeField] private TransitionSettings settings = new TransitionSettings();
+
+    /// <summary>Full C# type name of the Transition this asset configures.</summary>
+    public string TransitionTypeName => transitionTypeName;
+
+    /// <summary>Editable saved authoring values for the Transition.</summary>
+    public TransitionSettings Settings => settings ?? (settings = new TransitionSettings());
+
+    /// <summary>Initializes a newly created asset from a Transition's Code Defaults.</summary>
+    public void Initialize(string transitionTypeName, TransitionSettings codeDefaults)
+    {
+        if (string.IsNullOrWhiteSpace(transitionTypeName))
+        {
+            throw new ArgumentException("Transition type name is required.", nameof(transitionTypeName));
+        }
+
+        this.transitionTypeName = transitionTypeName;
+        RestoreDefaults(codeDefaults);
+    }
+
+    /// <summary>Copies a Transition's current Code Defaults over the saved settings.</summary>
+    public void RestoreDefaults(TransitionSettings codeDefaults)
+    {
+        Settings.CopyFrom(codeDefaults ?? throw new ArgumentNullException(nameof(codeDefaults)));
+    }
+}

--- a/Assets/core/TransitionSettingsAsset.cs.meta
+++ b/Assets/core/TransitionSettingsAsset.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ce8a1dd4452f439f9d89d2898dcafe3

--- a/Assets/core/TransitionSettingsProvider.cs
+++ b/Assets/core/TransitionSettingsProvider.cs
@@ -1,0 +1,35 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Resolves the effective Transition Settings for runtime code without depending on UnityEditor APIs.
+/// </summary>
+public static class TransitionSettingsProvider
+{
+    public const string ResourceFolder = "TransitionSettings";
+
+    /// <summary>Returns the Resources path used for a Transition's settings asset.</summary>
+    public static string ResourcePathFor(Type transitionType)
+    {
+        if (transitionType == null)
+        {
+            throw new ArgumentNullException(nameof(transitionType));
+        }
+
+        return $"{ResourceFolder}/{transitionType.Name}Settings";
+    }
+
+    /// <summary>
+    /// Reads the saved settings asset for the Transition when present; otherwise returns the supplied Code Defaults.
+    /// </summary>
+    public static TransitionSettings Resolve(Type transitionType, TransitionSettings codeDefaults)
+    {
+        if (codeDefaults == null)
+        {
+            throw new ArgumentNullException(nameof(codeDefaults));
+        }
+
+        var asset = Resources.Load<TransitionSettingsAsset>(ResourcePathFor(transitionType));
+        return asset != null ? asset.Settings : codeDefaults;
+    }
+}

--- a/Assets/core/TransitionSettingsProvider.cs.meta
+++ b/Assets/core/TransitionSettingsProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b4346f40cba8e435fb17c1f97dc19af7

--- a/Assets/transitions/DirectionalWipe.cs
+++ b/Assets/transitions/DirectionalWipe.cs
@@ -5,7 +5,7 @@ using Random = UnityEngine.Random;
 /// </summary>
 public class DirectionalWipe : TransitionBase
 {
-    // Hand-tuned DirectionalWipe settings. Keep these together so the transition
+    // Hand-tuned DirectionalWipe Code Defaults. Keep these together so the transition
     // can be adjusted by hand without hunting through the implementation.
     private const global::Repertoire DefaultTags = global::Repertoire.RespondsToEnergy;
     private const int RunwayBeats = 4;
@@ -14,10 +14,10 @@ public class DirectionalWipe : TransitionBase
     private const TransitionIntensity Intensity = TransitionIntensity.Medium;
     private const float DefaultDurationSeconds = 4f;
 
-    private const float RandomDirectionRangeRadians = Mathf.PI * 2f;
     private const float ExternalBlendDefaultProgress = 0.5f;
     private const float ExternalBlendDefaultAngleRadians = 0f;
 
+    private const float RandomDirectionRangeRadians = Mathf.PI * 2f;
     private const float ReactiveEdgeWidth = 0.055f;
     private const float BaseEdgeBrightnessBoost = 0.15f;
     private const float LowBandResponseGain = 2f;
@@ -25,16 +25,26 @@ public class DirectionalWipe : TransitionBase
     private const float BaseEdgeBrightnessLift = 0.025f;
     private const float MaxLowBandBrightnessLift = 0.14f;
 
-    private static readonly TransitionRepertoire DefaultRepertoire =
-        TransitionRepertoire.FromRunwayAndTail(
-            DefaultTags,
-            RunwayBeats,
-            TailBeats,
-            Shape,
-            Intensity,
-            DefaultDurationSeconds);
-
-    public override TransitionRepertoire Repertoire => DefaultRepertoire;
+    protected override TransitionSettings BuildCodeDefaults()
+    {
+        return new TransitionSettings
+        {
+            Tags = DefaultTags,
+            RunwayBeats = RunwayBeats,
+            TailBeats = TailBeats,
+            Shape = Shape,
+            Intensity = Intensity,
+            DefaultDurationSeconds = DefaultDurationSeconds,
+            ExternalBlendDefaultProgress = ExternalBlendDefaultProgress,
+            ExternalBlendDefaultAngleRadians = ExternalBlendDefaultAngleRadians,
+            DirectionalReactiveEdgeWidth = ReactiveEdgeWidth,
+            DirectionalBaseEdgeBrightnessBoost = BaseEdgeBrightnessBoost,
+            DirectionalLowBandResponseGain = LowBandResponseGain,
+            DirectionalMaxLowBandBrightnessBoost = MaxLowBandBrightnessBoost,
+            DirectionalBaseEdgeBrightnessLift = BaseEdgeBrightnessLift,
+            DirectionalMaxLowBandBrightnessLift = MaxLowBandBrightnessLift,
+        };
+    }
 
     float angle;
     float diagonalsize;
@@ -92,13 +102,13 @@ public class DirectionalWipe : TransitionBase
     {
         controller.effects[A].Draw();
         controller.effects[B].Draw();
-        Draw2(buffer, controller.effects[A].buffer, controller.effects[B].buffer, V, angle);
+        Draw2(buffer, controller.effects[A].buffer, controller.effects[B].buffer, V, angle, EffectiveSettings);
     }
 
     /// <summary>
     /// Shared directional wipe implementation for normal transitions and external blending.
     /// </summary>
-    private void Draw2(Color[] dest, Color[] src1, Color[] src2, float V2, float Angle2)
+    private void Draw2(Color[] dest, Color[] src1, Color[] src2, float V2, float Angle2, TransitionSettings transitionSettings)
     {
         float lowBandLevel = CurrentLowBandLevel();
 
@@ -107,8 +117,8 @@ public class DirectionalWipe : TransitionBase
             Vector2 point = rotate(controller.penrose.tiles[i].position, Angle2);
             float projectedProgress = (point.x + diagonalsize / 2f) / diagonalsize;
             Color baseColor = projectedProgress >= V2 ? src1[i] : src2[i];
-            float edgePresence = EdgePresence(projectedProgress, V2);
-            dest[i] = ApplyLowBandEdgeBrightness(baseColor, edgePresence, lowBandLevel);
+            float edgePresence = EdgePresence(projectedProgress, V2, transitionSettings.DirectionalReactiveEdgeWidth);
+            dest[i] = ApplyLowBandEdgeBrightness(baseColor, edgePresence, lowBandLevel, transitionSettings);
         }
     }
 
@@ -127,7 +137,12 @@ public class DirectionalWipe : TransitionBase
     /// </summary>
     public static float EdgePresence(float projectedProgress, float transitionProgress)
     {
-        return 1f - Mathf.Clamp01(Mathf.Abs(projectedProgress - transitionProgress) / ReactiveEdgeWidth);
+        return EdgePresence(projectedProgress, transitionProgress, ReactiveEdgeWidth);
+    }
+
+    private static float EdgePresence(float projectedProgress, float transitionProgress, float reactiveEdgeWidth)
+    {
+        return 1f - Mathf.Clamp01(Mathf.Abs(projectedProgress - transitionProgress) / reactiveEdgeWidth);
     }
 
     /// <summary>
@@ -149,6 +164,26 @@ public class DirectionalWipe : TransitionBase
             color.a);
     }
 
+    private static Color ApplyLowBandEdgeBrightness(
+        Color color,
+        float edgePresence,
+        float lowBandLevel,
+        TransitionSettings transitionSettings)
+    {
+        float edge = Mathf.Clamp01(edgePresence);
+        if (edge <= 0f)
+        {
+            return color;
+        }
+
+        float reactiveInfluence = edge * Mathf.Clamp01(lowBandLevel * transitionSettings.DirectionalLowBandResponseGain);
+        return new Color(
+            BrightenChannel(color.r, edge, reactiveInfluence, transitionSettings),
+            BrightenChannel(color.g, edge, reactiveInfluence, transitionSettings),
+            BrightenChannel(color.b, edge, reactiveInfluence, transitionSettings),
+            color.a);
+    }
+
     private static float BrightenChannel(float channel, float edgePresence, float reactiveInfluence)
     {
         return Mathf.Clamp01(
@@ -157,18 +192,27 @@ public class DirectionalWipe : TransitionBase
             + reactiveInfluence * MaxLowBandBrightnessLift);
     }
 
+    private static float BrightenChannel(float channel, float edgePresence, float reactiveInfluence, TransitionSettings transitionSettings)
+    {
+        return Mathf.Clamp01(
+            channel * (1f + edgePresence * transitionSettings.DirectionalBaseEdgeBrightnessBoost + reactiveInfluence * transitionSettings.DirectionalMaxLowBandBrightnessBoost)
+            + edgePresence * transitionSettings.DirectionalBaseEdgeBrightnessLift
+            + reactiveInfluence * transitionSettings.DirectionalMaxLowBandBrightnessLift);
+    }
+
     /// <summary>
     /// Uses this transition algorithm as an external-source blender.
     /// </summary>
     public override void Blend(Color[] dest, Color[] src1, Color[] src2)
     {
-        float V2 = ExternalBlendDefaultProgress;
-        float Angle2 = ExternalBlendDefaultAngleRadians;
+        var effectiveSettings = EffectiveSettings;
+        float V2 = effectiveSettings.ExternalBlendDefaultProgress;
+        float Angle2 = effectiveSettings.ExternalBlendDefaultAngleRadians;
         if (settings.Length > 0)
             V2 = settings[0];
         if (settings.Length > 1)
             Angle2 = settings[1];
-        Draw2(dest, src1, src2, V2, Angle2);
+        Draw2(dest, src1, src2, V2, Angle2, effectiveSettings);
     }
     /// <summary>
     /// Returns the external-blender fader argument format for this transition.

--- a/Assets/transitions/Fade.cs
+++ b/Assets/transitions/Fade.cs
@@ -4,16 +4,27 @@
 /// </summary>
 public class Fade : TransitionBase
 {
-    private static readonly TransitionRepertoire DefaultRepertoire =
-        TransitionRepertoire.FromRunwayAndTail(
-            global::Repertoire.None,
-            runwayBeats: 4,
-            tailBeats: 0,
-            TransitionShape.Blend,
-            TransitionIntensity.Subtle,
-            defaultDurationSeconds: 4f);
+    private const global::Repertoire DefaultTags = global::Repertoire.None;
+    private const int RunwayBeats = 4;
+    private const int TailBeats = 0;
+    private const TransitionShape Shape = TransitionShape.Blend;
+    private const TransitionIntensity Intensity = TransitionIntensity.Subtle;
+    private const float DefaultDurationSeconds = 4f;
+    private const float ExternalBlendDefaultProgress = 0.5f;
 
-    public override TransitionRepertoire Repertoire => DefaultRepertoire;
+    protected override TransitionSettings BuildCodeDefaults()
+    {
+        return new TransitionSettings
+        {
+            Tags = DefaultTags,
+            RunwayBeats = RunwayBeats,
+            TailBeats = TailBeats,
+            Shape = Shape,
+            Intensity = Intensity,
+            DefaultDurationSeconds = DefaultDurationSeconds,
+            ExternalBlendDefaultProgress = ExternalBlendDefaultProgress,
+        };
+    }
 
     /// <summary>
     /// Initializes per-run transition state before effect-to-effect blending begins.
@@ -51,7 +62,7 @@ public class Fade : TransitionBase
     /// </summary>
     public override void Blend(Color[] dest, Color[] src1, Color[] src2)
     {
-        float V2 = 0.5f;
+        float V2 = EffectiveSettings.ExternalBlendDefaultProgress;
         if (settings.Length > 0)
             V2 = settings[0];
         Draw2(dest, src1, src2, V2, 1f - V2);

--- a/Assets/transitions/FizzleTransition.cs
+++ b/Assets/transitions/FizzleTransition.cs
@@ -7,16 +7,27 @@ using Random = UnityEngine.Random;
 /// </summary>
 public class FizzleTransition : TransitionBase
 {
-    private static readonly TransitionRepertoire DefaultRepertoire =
-        TransitionRepertoire.FromRunwayAndTail(
-            global::Repertoire.HandlesDrop,
-            runwayBeats: 4,
-            tailBeats: 4,
-            TransitionShape.Dissolve,
-            TransitionIntensity.High,
-            defaultDurationSeconds: 4f);
+    private const global::Repertoire DefaultTags = global::Repertoire.HandlesDrop;
+    private const int RunwayBeats = 4;
+    private const int TailBeats = 4;
+    private const TransitionShape Shape = TransitionShape.Dissolve;
+    private const TransitionIntensity Intensity = TransitionIntensity.High;
+    private const float DefaultDurationSeconds = 4f;
+    private const float ExternalBlendDefaultProgress = 0.5f;
 
-    public override TransitionRepertoire Repertoire => DefaultRepertoire;
+    protected override TransitionSettings BuildCodeDefaults()
+    {
+        return new TransitionSettings
+        {
+            Tags = DefaultTags,
+            RunwayBeats = RunwayBeats,
+            TailBeats = TailBeats,
+            Shape = Shape,
+            Intensity = Intensity,
+            DefaultDurationSeconds = DefaultDurationSeconds,
+            ExternalBlendDefaultProgress = ExternalBlendDefaultProgress,
+        };
+    }
 
     short[] order = null;
     public override void OnStart()
@@ -95,7 +106,7 @@ public class FizzleTransition : TransitionBase
     /// </summary>
     public override void Blend(Color[] dest, Color[] src1, Color[] src2)
     {
-        float V2 = 0.5f;
+        float V2 = EffectiveSettings.ExternalBlendDefaultProgress;
         if (settings.Length > 0)
             V2 = settings[0];
         Draw2(dest, src1, src2, V2);

--- a/Assets/transitions/IndexWipe.cs
+++ b/Assets/transitions/IndexWipe.cs
@@ -4,16 +4,27 @@
 /// </summary>
 public class IndexWipe : TransitionBase
 {
-    private static readonly TransitionRepertoire DefaultRepertoire =
-        TransitionRepertoire.FromRunwayAndTail(
-            global::Repertoire.None,
-            runwayBeats: 4,
-            tailBeats: 0,
-            TransitionShape.IndexWipe,
-            TransitionIntensity.Medium,
-            defaultDurationSeconds: 4f);
+    private const global::Repertoire DefaultTags = global::Repertoire.None;
+    private const int RunwayBeats = 4;
+    private const int TailBeats = 0;
+    private const TransitionShape Shape = TransitionShape.IndexWipe;
+    private const TransitionIntensity Intensity = TransitionIntensity.Medium;
+    private const float DefaultDurationSeconds = 4f;
+    private const float ExternalBlendDefaultProgress = 0.5f;
 
-    public override TransitionRepertoire Repertoire => DefaultRepertoire;
+    protected override TransitionSettings BuildCodeDefaults()
+    {
+        return new TransitionSettings
+        {
+            Tags = DefaultTags,
+            RunwayBeats = RunwayBeats,
+            TailBeats = TailBeats,
+            Shape = Shape,
+            Intensity = Intensity,
+            DefaultDurationSeconds = DefaultDurationSeconds,
+            ExternalBlendDefaultProgress = ExternalBlendDefaultProgress,
+        };
+    }
 
     /// <summary>
     /// Initializes per-run transition state before effect-to-effect blending begins.
@@ -59,7 +70,7 @@ public class IndexWipe : TransitionBase
     public override void Blend(Color[] dest, Color[] src1, Color[] src2)
     {
         //        OnInit();
-        float V2 = 0.5f;
+        float V2 = EffectiveSettings.ExternalBlendDefaultProgress;
         if (settings.Length > 0)
             V2 = settings[0];
         Draw2(dest, src1, src2, V2);

--- a/Assets/transitions/IrisTransition.cs
+++ b/Assets/transitions/IrisTransition.cs
@@ -7,16 +7,29 @@ using Random = UnityEngine.Random;
 /// </summary>
 public class IrisTransition : TransitionBase
 {
-    private static readonly TransitionRepertoire DefaultRepertoire =
-        TransitionRepertoire.FromRunwayAndTail(
-            global::Repertoire.HandlesDrop,
-            runwayBeats: 4,
-            tailBeats: 4,
-            TransitionShape.Iris,
-            TransitionIntensity.High,
-            defaultDurationSeconds: 4f);
+    private const global::Repertoire DefaultTags = global::Repertoire.HandlesDrop;
+    private const int RunwayBeats = 4;
+    private const int TailBeats = 4;
+    private const TransitionShape Shape = TransitionShape.Iris;
+    private const TransitionIntensity Intensity = TransitionIntensity.High;
+    private const float DefaultDurationSeconds = 4f;
+    private const float ExternalBlendDefaultProgress = 0.5f;
+    private const float ExternalBlendDefaultDirection = 0f;
 
-    public override TransitionRepertoire Repertoire => DefaultRepertoire;
+    protected override TransitionSettings BuildCodeDefaults()
+    {
+        return new TransitionSettings
+        {
+            Tags = DefaultTags,
+            RunwayBeats = RunwayBeats,
+            TailBeats = TailBeats,
+            Shape = Shape,
+            Intensity = Intensity,
+            DefaultDurationSeconds = DefaultDurationSeconds,
+            ExternalBlendDefaultProgress = ExternalBlendDefaultProgress,
+            ExternalBlendDefaultDirection = ExternalBlendDefaultDirection,
+        };
+    }
 
     int direction;
     float diagonalsize;
@@ -106,13 +119,13 @@ public class IrisTransition : TransitionBase
     /// </summary>
     public override void Blend(Color[] dest, Color[] src1, Color[] src2)
     {
-        float V2 = 0.5f;
-        int d = 0;
+        var effectiveSettings = EffectiveSettings;
+        float V2 = effectiveSettings.ExternalBlendDefaultProgress;
+        int d = effectiveSettings.ExternalBlendDefaultDirection > 0.5f ? 1 : 0;
         if (settings.Length > 0)
             V2 = settings[0];
         if (settings.Length > 1)
-            if (settings[1] > 0.5f)
-                d = 1;
+            d = settings[1] > 0.5f ? 1 : 0;
         Draw2(dest, src1, src2, V2, d);
     }
     /// <summary>

--- a/Assets/transitions/NoiseTransition.cs
+++ b/Assets/transitions/NoiseTransition.cs
@@ -8,16 +8,35 @@ using UnityEngine;
 /// </summary>
 public class NoiseTransition : TransitionBase
 {
-    private static readonly TransitionRepertoire DefaultRepertoire =
-        TransitionRepertoire.FromRunwayAndTail(
-            global::Repertoire.HandlesDrop | global::Repertoire.RespondsToEnergy,
-            runwayBeats: 4,
-            tailBeats: 4,
-            TransitionShape.Noise,
-            TransitionIntensity.High,
-            defaultDurationSeconds: 4f);
+    private const global::Repertoire DefaultTags = global::Repertoire.HandlesDrop | global::Repertoire.RespondsToEnergy;
+    private const int RunwayBeats = 4;
+    private const int TailBeats = 4;
+    private const TransitionShape Shape = TransitionShape.Noise;
+    private const TransitionIntensity Intensity = TransitionIntensity.High;
+    private const float DefaultDurationSeconds = 4f;
+    private const float ExternalBlendDefaultProgress = 0.5f;
+    private const float ExternalBlendDefaultBorderHue = 0f;
+    private const float NoiseScale = 0.07f;
+    private const float NoiseProgressRange = 1.1f;
+    private const float NoiseBorderWidth = 0.1f;
 
-    public override TransitionRepertoire Repertoire => DefaultRepertoire;
+    protected override TransitionSettings BuildCodeDefaults()
+    {
+        return new TransitionSettings
+        {
+            Tags = DefaultTags,
+            RunwayBeats = RunwayBeats,
+            TailBeats = TailBeats,
+            Shape = Shape,
+            Intensity = Intensity,
+            DefaultDurationSeconds = DefaultDurationSeconds,
+            ExternalBlendDefaultProgress = ExternalBlendDefaultProgress,
+            ExternalBlendDefaultBorderHue = ExternalBlendDefaultBorderHue,
+            NoiseScale = NoiseScale,
+            NoiseProgressRange = NoiseProgressRange,
+            NoiseBorderWidth = NoiseBorderWidth,
+        };
+    }
 
     private Color border;
     public override void OnStart()
@@ -38,29 +57,28 @@ public class NoiseTransition : TransitionBase
     {
         controller.effects[A].Draw();
         controller.effects[B].Draw();
-        Draw2(buffer, controller.effects[A].buffer, controller.effects[B].buffer, V, border);
+        Draw2(buffer, controller.effects[A].buffer, controller.effects[B].buffer, V, border, EffectiveSettings);
     }
 
     /// <summary>
     /// Shared Perlin-threshold implementation for normal transitions and external blending.
     /// </summary>
-    private void Draw2(Color[] dest, Color[] src1, Color[] src2, float V2, Color brd)
+    private void Draw2(Color[] dest, Color[] src1, Color[] src2, float V2, Color brd, TransitionSettings transitionSettings)
     {
-        float v2 = V2.Map(0f, 1f, -1.1f, 1.1f);
+        float v2 = V2.Map(0f, 1f, -transitionSettings.NoiseProgressRange, transitionSettings.NoiseProgressRange);
 
         for (int i = 0; i < buffer.Length; i++)
         {
-            float scale = 0.07f;
-            float x = controller.penrose.tiles[i].center.x * scale;
-            float y = controller.penrose.tiles[i].center.y * scale;
+            float x = controller.penrose.tiles[i].center.x * transitionSettings.NoiseScale;
+            float y = controller.penrose.tiles[i].center.y * transitionSettings.NoiseScale;
             float z = effectTime;
 
             float n = Perlin.Noise(x, y, z);
             n += v2;
 
-            if (n > 0.1)
+            if (n > transitionSettings.NoiseBorderWidth)
                 dest[i] = src2[i];
-            else if (n > -0.1)
+            else if (n > -transitionSettings.NoiseBorderWidth)
                 dest[i] = brd;
             else
                 dest[i] = src1[i];
@@ -72,14 +90,15 @@ public class NoiseTransition : TransitionBase
     /// </summary>
     public override void Blend(Color[] dest, Color[] src1, Color[] src2)
     {
-        float V2 = 0.5f;
-        Color brd = Color.HSVToRGB(0, 1, 1);
+        var effectiveSettings = EffectiveSettings;
+        float V2 = effectiveSettings.ExternalBlendDefaultProgress;
+        Color brd = Color.HSVToRGB(effectiveSettings.ExternalBlendDefaultBorderHue, 1, 1);
         if (settings.Length > 0)
             V2 = settings[0];
         if (settings.Length > 1)
-            brd = brd = Color.HSVToRGB(settings[1], 1, 1);
+            brd = Color.HSVToRGB(settings[1], 1, 1);
 
-        Draw2(dest, src1, src2, V2, brd);
+        Draw2(dest, src1, src2, V2, brd, effectiveSettings);
     }
     /// <summary>
     /// Returns the external-blender fader argument format for this transition.

--- a/Assets/transitions/RGBFade.cs
+++ b/Assets/transitions/RGBFade.cs
@@ -5,16 +5,27 @@
 /// </summary>
 public class RGBFade : TransitionBase
 {
-    private static readonly TransitionRepertoire DefaultRepertoire =
-        TransitionRepertoire.FromRunwayAndTail(
-            global::Repertoire.RespondsToEnergy,
-            runwayBeats: 4,
-            tailBeats: 4,
-            TransitionShape.ChannelBlend,
-            TransitionIntensity.Medium,
-            defaultDurationSeconds: 4f);
+    private const global::Repertoire DefaultTags = global::Repertoire.RespondsToEnergy;
+    private const int RunwayBeats = 4;
+    private const int TailBeats = 4;
+    private const TransitionShape Shape = TransitionShape.ChannelBlend;
+    private const TransitionIntensity Intensity = TransitionIntensity.Medium;
+    private const float DefaultDurationSeconds = 4f;
+    private const float ExternalBlendDefaultProgress = 0.5f;
 
-    public override TransitionRepertoire Repertoire => DefaultRepertoire;
+    protected override TransitionSettings BuildCodeDefaults()
+    {
+        return new TransitionSettings
+        {
+            Tags = DefaultTags,
+            RunwayBeats = RunwayBeats,
+            TailBeats = TailBeats,
+            Shape = Shape,
+            Intensity = Intensity,
+            DefaultDurationSeconds = DefaultDurationSeconds,
+            ExternalBlendDefaultProgress = ExternalBlendDefaultProgress,
+        };
+    }
 
     /// <summary>
     /// Initializes per-run transition state before effect-to-effect blending begins.
@@ -60,7 +71,7 @@ public class RGBFade : TransitionBase
     /// </summary>
     public override void Blend(Color[] dest, Color[] src1, Color[] src2)
     {
-        float V2 = 0.5f;
+        float V2 = EffectiveSettings.ExternalBlendDefaultProgress;
         if (settings.Length > 0)
             V2 = settings[0];
 
@@ -71,7 +82,7 @@ public class RGBFade : TransitionBase
     /// </summary>
     public override string Usage()
     {
-        return "[ratio] [borderHue]";
+        return "[ratio]";
     }
 
 

--- a/Assets/transitions/Resources.meta
+++ b/Assets/transitions/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ad31785feae0470eb9306524210db69
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/transitions/Resources/TransitionSettings.meta
+++ b/Assets/transitions/Resources/TransitionSettings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9dae3e800da2b4b5992be03a39434a95
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/transitions/Resources/TransitionSettings/DirectionalWipeSettings.asset
+++ b/Assets/transitions/Resources/TransitionSettings/DirectionalWipeSettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ce8a1dd4452f439f9d89d2898dcafe3, type: 3}
+  m_Name: DirectionalWipeSettings
+  m_EditorClassIdentifier: Assembly-CSharp::TransitionSettingsAsset
+  transitionTypeName: DirectionalWipe
+  settings:
+    Tags: 4
+    RunwayBeats: 4
+    TailBeats: 4
+    Shape: 2
+    Intensity: 1
+    DefaultDurationSeconds: 4
+    ExternalBlendDefaultProgress: 0.5
+    ExternalBlendDefaultAngleRadians: 0
+    ExternalBlendDefaultDirection: 0
+    ExternalBlendDefaultBorderHue: 0
+    DirectionalReactiveEdgeWidth: 0.055
+    DirectionalBaseEdgeBrightnessBoost: 0.15
+    DirectionalLowBandResponseGain: 2
+    DirectionalMaxLowBandBrightnessBoost: 0.85
+    DirectionalBaseEdgeBrightnessLift: 0.025
+    DirectionalMaxLowBandBrightnessLift: 0.14
+    NoiseScale: 0.07
+    NoiseProgressRange: 1.1
+    NoiseBorderWidth: 0.1

--- a/Assets/transitions/Resources/TransitionSettings/DirectionalWipeSettings.asset.meta
+++ b/Assets/transitions/Resources/TransitionSettings/DirectionalWipeSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e462edf51739343a0a828dd771c0ce05
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/transitions/Resources/TransitionSettings/FadeSettings.asset
+++ b/Assets/transitions/Resources/TransitionSettings/FadeSettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ce8a1dd4452f439f9d89d2898dcafe3, type: 3}
+  m_Name: FadeSettings
+  m_EditorClassIdentifier: Assembly-CSharp::TransitionSettingsAsset
+  transitionTypeName: Fade
+  settings:
+    Tags: 0
+    RunwayBeats: 4
+    TailBeats: 0
+    Shape: 0
+    Intensity: 0
+    DefaultDurationSeconds: 4
+    ExternalBlendDefaultProgress: 0.5
+    ExternalBlendDefaultAngleRadians: 0
+    ExternalBlendDefaultDirection: 0
+    ExternalBlendDefaultBorderHue: 0
+    DirectionalReactiveEdgeWidth: 0.055
+    DirectionalBaseEdgeBrightnessBoost: 0.15
+    DirectionalLowBandResponseGain: 2
+    DirectionalMaxLowBandBrightnessBoost: 0.85
+    DirectionalBaseEdgeBrightnessLift: 0.025
+    DirectionalMaxLowBandBrightnessLift: 0.14
+    NoiseScale: 0.07
+    NoiseProgressRange: 1.1
+    NoiseBorderWidth: 0.1

--- a/Assets/transitions/Resources/TransitionSettings/FadeSettings.asset.meta
+++ b/Assets/transitions/Resources/TransitionSettings/FadeSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3cab4e25bcb65423997df1fa45db96a5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/transitions/Resources/TransitionSettings/FizzleTransitionSettings.asset
+++ b/Assets/transitions/Resources/TransitionSettings/FizzleTransitionSettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ce8a1dd4452f439f9d89d2898dcafe3, type: 3}
+  m_Name: FizzleTransitionSettings
+  m_EditorClassIdentifier: Assembly-CSharp::TransitionSettingsAsset
+  transitionTypeName: FizzleTransition
+  settings:
+    Tags: 2
+    RunwayBeats: 4
+    TailBeats: 4
+    Shape: 4
+    Intensity: 2
+    DefaultDurationSeconds: 4
+    ExternalBlendDefaultProgress: 0.5
+    ExternalBlendDefaultAngleRadians: 0
+    ExternalBlendDefaultDirection: 0
+    ExternalBlendDefaultBorderHue: 0
+    DirectionalReactiveEdgeWidth: 0.055
+    DirectionalBaseEdgeBrightnessBoost: 0.15
+    DirectionalLowBandResponseGain: 2
+    DirectionalMaxLowBandBrightnessBoost: 0.85
+    DirectionalBaseEdgeBrightnessLift: 0.025
+    DirectionalMaxLowBandBrightnessLift: 0.14
+    NoiseScale: 0.07
+    NoiseProgressRange: 1.1
+    NoiseBorderWidth: 0.1

--- a/Assets/transitions/Resources/TransitionSettings/FizzleTransitionSettings.asset.meta
+++ b/Assets/transitions/Resources/TransitionSettings/FizzleTransitionSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3f8f8774a8cd49b9bb5e36af846f9e2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/transitions/Resources/TransitionSettings/IndexWipeSettings.asset
+++ b/Assets/transitions/Resources/TransitionSettings/IndexWipeSettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ce8a1dd4452f439f9d89d2898dcafe3, type: 3}
+  m_Name: IndexWipeSettings
+  m_EditorClassIdentifier: Assembly-CSharp::TransitionSettingsAsset
+  transitionTypeName: IndexWipe
+  settings:
+    Tags: 0
+    RunwayBeats: 4
+    TailBeats: 0
+    Shape: 3
+    Intensity: 1
+    DefaultDurationSeconds: 4
+    ExternalBlendDefaultProgress: 0.5
+    ExternalBlendDefaultAngleRadians: 0
+    ExternalBlendDefaultDirection: 0
+    ExternalBlendDefaultBorderHue: 0
+    DirectionalReactiveEdgeWidth: 0.055
+    DirectionalBaseEdgeBrightnessBoost: 0.15
+    DirectionalLowBandResponseGain: 2
+    DirectionalMaxLowBandBrightnessBoost: 0.85
+    DirectionalBaseEdgeBrightnessLift: 0.025
+    DirectionalMaxLowBandBrightnessLift: 0.14
+    NoiseScale: 0.07
+    NoiseProgressRange: 1.1
+    NoiseBorderWidth: 0.1

--- a/Assets/transitions/Resources/TransitionSettings/IndexWipeSettings.asset.meta
+++ b/Assets/transitions/Resources/TransitionSettings/IndexWipeSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 93098fa6248d74facb0a4397cde63cf5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/transitions/Resources/TransitionSettings/IrisTransitionSettings.asset
+++ b/Assets/transitions/Resources/TransitionSettings/IrisTransitionSettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ce8a1dd4452f439f9d89d2898dcafe3, type: 3}
+  m_Name: IrisTransitionSettings
+  m_EditorClassIdentifier: Assembly-CSharp::TransitionSettingsAsset
+  transitionTypeName: IrisTransition
+  settings:
+    Tags: 2
+    RunwayBeats: 4
+    TailBeats: 4
+    Shape: 5
+    Intensity: 2
+    DefaultDurationSeconds: 4
+    ExternalBlendDefaultProgress: 0.5
+    ExternalBlendDefaultAngleRadians: 0
+    ExternalBlendDefaultDirection: 0
+    ExternalBlendDefaultBorderHue: 0
+    DirectionalReactiveEdgeWidth: 0.055
+    DirectionalBaseEdgeBrightnessBoost: 0.15
+    DirectionalLowBandResponseGain: 2
+    DirectionalMaxLowBandBrightnessBoost: 0.85
+    DirectionalBaseEdgeBrightnessLift: 0.025
+    DirectionalMaxLowBandBrightnessLift: 0.14
+    NoiseScale: 0.07
+    NoiseProgressRange: 1.1
+    NoiseBorderWidth: 0.1

--- a/Assets/transitions/Resources/TransitionSettings/IrisTransitionSettings.asset.meta
+++ b/Assets/transitions/Resources/TransitionSettings/IrisTransitionSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ca48d340e1ef4db187493380864c4b2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/transitions/Resources/TransitionSettings/NoiseTransitionSettings.asset
+++ b/Assets/transitions/Resources/TransitionSettings/NoiseTransitionSettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ce8a1dd4452f439f9d89d2898dcafe3, type: 3}
+  m_Name: NoiseTransitionSettings
+  m_EditorClassIdentifier: Assembly-CSharp::TransitionSettingsAsset
+  transitionTypeName: NoiseTransition
+  settings:
+    Tags: 6
+    RunwayBeats: 4
+    TailBeats: 4
+    Shape: 6
+    Intensity: 2
+    DefaultDurationSeconds: 4
+    ExternalBlendDefaultProgress: 0.5
+    ExternalBlendDefaultAngleRadians: 0
+    ExternalBlendDefaultDirection: 0
+    ExternalBlendDefaultBorderHue: 0
+    DirectionalReactiveEdgeWidth: 0.055
+    DirectionalBaseEdgeBrightnessBoost: 0.15
+    DirectionalLowBandResponseGain: 2
+    DirectionalMaxLowBandBrightnessBoost: 0.85
+    DirectionalBaseEdgeBrightnessLift: 0.025
+    DirectionalMaxLowBandBrightnessLift: 0.14
+    NoiseScale: 0.07
+    NoiseProgressRange: 1.1
+    NoiseBorderWidth: 0.1

--- a/Assets/transitions/Resources/TransitionSettings/NoiseTransitionSettings.asset.meta
+++ b/Assets/transitions/Resources/TransitionSettings/NoiseTransitionSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d931a0ec86b1741cc9a3f194a3a106b7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/transitions/Resources/TransitionSettings/RGBFadeSettings.asset
+++ b/Assets/transitions/Resources/TransitionSettings/RGBFadeSettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ce8a1dd4452f439f9d89d2898dcafe3, type: 3}
+  m_Name: RGBFadeSettings
+  m_EditorClassIdentifier: Assembly-CSharp::TransitionSettingsAsset
+  transitionTypeName: RGBFade
+  settings:
+    Tags: 4
+    RunwayBeats: 4
+    TailBeats: 4
+    Shape: 1
+    Intensity: 1
+    DefaultDurationSeconds: 4
+    ExternalBlendDefaultProgress: 0.5
+    ExternalBlendDefaultAngleRadians: 0
+    ExternalBlendDefaultDirection: 0
+    ExternalBlendDefaultBorderHue: 0
+    DirectionalReactiveEdgeWidth: 0.055
+    DirectionalBaseEdgeBrightnessBoost: 0.15
+    DirectionalLowBandResponseGain: 2
+    DirectionalMaxLowBandBrightnessBoost: 0.85
+    DirectionalBaseEdgeBrightnessLift: 0.025
+    DirectionalMaxLowBandBrightnessLift: 0.14
+    NoiseScale: 0.07
+    NoiseProgressRange: 1.1
+    NoiseBorderWidth: 0.1

--- a/Assets/transitions/Resources/TransitionSettings/RGBFadeSettings.asset.meta
+++ b/Assets/transitions/Resources/TransitionSettings/RGBFadeSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 914e7594f5994493a8bc0d14360e917c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- stage Director next effect/transition choices and expose runtime steering status
- persist complete Transition Settings assets from code defaults
- add the Penrose Tuning Window for transition settings and Play Mode steering/Hold Selected

## Validation
- scripts/unity-compile.sh
- scripts/unity-tests.sh (135/135 passed)
- git diff --check

## Notes
- Manual Play Mode review is the remaining hands-on check for UI feel.
- The separate tailed-transition phase-anchor bug is tracked locally under .scratch/transition-tail-phase-anchor/ and intentionally deferred.