### PR TITLE
refactor(rhythm): polish names and docs across the Rhythm partials

### DIFF
--- a/Assets/core/Rhythm/BeatManager.cs
+++ b/Assets/core/Rhythm/BeatManager.cs
@@ -105,7 +105,7 @@ public partial class BeatManager
 
         // Derivation and shaping run after wireSnapshot has settled for this frame so contrived values
         // never lag the transport by a frame or shape from stale data across a source switch.
-        DeriveBeatState();
+        DeriveOffBeats();
         UpdateLevelsShaping(timeSeconds);
 
         // Capture last so every reader sees one frame-coherent musical snapshot.
@@ -181,16 +181,7 @@ public partial class BeatManager
     }
 
     /// <summary>
-    /// Contrives the locally derived beat state from the transport fields. Runs once per frame from
-    /// <see cref="Update"/> after the live source has written <see cref="wireSnapshot"/>.
-    /// </summary>
-    private void DeriveBeatState()
-    {
-        DeriveOffBeats();
-    }
-
-    /// <summary>
-    /// Resets Levels and the Phrase, Drop, Fill, Energy, Loop, Grid, and Track ID facts to unavailable.
+    /// Resets on-air analysis and reactive facts to their unavailable wire values.
     /// </summary>
     /// <remarks>
     /// Standalone is a no-beat state, not a musical analysis, so it must never present phrase data. Running
@@ -198,7 +189,7 @@ public partial class BeatManager
     /// after a RaveSystem broadcast stops, so the captured groups return null values instead of
     /// replaying the last live Fill/Drop/Energy forever.
     /// </remarks>
-    private void ClearPhraseAndLevelState()
+    private void ClearOnAirAnalysisState()
     {
         wireSnapshot.levels = PenroseArt.RaveOsc.Levels.Unavailable;
         wireSnapshot.phraseState = PhraseState.Unavailable;
@@ -220,7 +211,7 @@ public partial class BeatManager
     {
         wireSnapshot.playersLive = "";
         wireSnapshot.track = "";
-        wireSnapshot.bpm = UnavailableMs; // wire sentinel: no usable tempo
+        wireSnapshot.bpm = -1f; // wire sentinel: no usable tempo
         wireSnapshot.beat = new BeatPosition { current = -1, total = -1 };
         wireSnapshot.bar = new BarPosition { current = -1, nextMs = -1 };
         wireSnapshot.beatInBar = -1; // real 4-count sentinel (musically 1..4 or -1, never 0); clears IsSynced
@@ -228,7 +219,7 @@ public partial class BeatManager
         wireSnapshot.beatPulse = 0f;
         wireSnapshot.beatsCountMs = CreateUnavailableCountdowns();
         wireSnapshot.onBeats = new bool[BeatSlotCount];
-        ClearPhraseAndLevelState();
+        ClearOnAirAnalysisState();
         ClearPlayersToNoBeat();
     }
 
@@ -242,5 +233,4 @@ public partial class BeatManager
         }
         return countdowns;
     }
-
 }

--- a/Assets/core/Rhythm/GridValues.cs
+++ b/Assets/core/Rhythm/GridValues.cs
@@ -4,7 +4,7 @@
 using System;
 using UnityEngine;
 
-/// <summary>How much the sender trusts the current sixteen-beat grid placement.</summary>
+/// <summary>How much the sender trusts the current phrase-relative timing-grid placement.</summary>
 public enum GridState
 {
     /// <summary>The grid is freshly placed and trusted.</summary>
@@ -15,10 +15,10 @@ public enum GridState
     Disputed,
 }
 
-/// <summary>Immutable sixteen-beat timing-grid wire facts and derived position.</summary>
+/// <summary>Immutable phrase-relative timing-grid wire facts and derived position.</summary>
 public readonly struct GridValues
 {
-    /// <summary>Number of beats in the timing-grid cycle.</summary>
+    /// <summary>Nominal number of positions in one complete timing-grid cycle.</summary>
     private const float CycleBeats = 16f;
     /// <summary>Continuous elapsed position retained for Build and Decay.</summary>
     private readonly float? elapsedBeats;
@@ -35,25 +35,31 @@ public readonly struct GridValues
 
     /// <summary>The sender's trust state.</summary>
     public GridState? State { get; }
-    /// <summary>One-based beat within the sixteen-beat grid.</summary>
+    /// <summary>One-based position within the phrase-relative 16-position timing-grid cycle.</summary>
     public int? Beat { get; }
-    /// <summary>One-based bar within the four-bar grid.</summary>
+    /// <summary>One-based four-beat subdivision within the timing-grid cycle.</summary>
     public int? Bar { get; }
     /// <summary>Derived 0..1 position through the grid.</summary>
     public float? Progress { get; }
 
-    /// <summary>Rises across the full grid or requested beat duration.</summary>
+    /// <summary>
+    /// Rises across the nominal 16-beat cycle or requested duration; a phrase boundary may restart
+    /// the observed grid before that nominal cycle completes.
+    /// </summary>
     public float Build(float? durationBeats = null) =>
         StockEnvelopes.Build(elapsedBeats, durationBeats ?? CycleBeats);
 
-    /// <summary>Falls across the full grid or requested beat duration.</summary>
+    /// <summary>
+    /// Falls across the nominal 16-beat cycle or requested duration; a phrase boundary may restart
+    /// the observed grid before that nominal cycle completes.
+    /// </summary>
     public float Decay(float? durationBeats = null) =>
         StockEnvelopes.Decay(elapsedBeats, durationBeats ?? CycleBeats);
 }
 
 public partial class BeatManager
 {
-    /// <summary>The sixteen-beat timing grid and its derived values.</summary>
+    /// <summary>The phrase-relative timing grid and its derived values.</summary>
     public GridValues Grid { get; private set; }
 
     /// <summary>Captures the settled timing-grid wire lane.</summary>

--- a/Assets/core/Rhythm/LevelsValues.cs
+++ b/Assets/core/Rhythm/LevelsValues.cs
@@ -36,7 +36,18 @@ public readonly struct LevelBands
     /// <summary>The strongest band's value.</summary>
     public float Strongest => Mathf.Max(Low, Mathf.Max(Mid, High));
     /// <summary>The strongest band, with ties resolved Low then Mid then High.</summary>
-    public Band StrongestBand => Low >= Mid && Low >= High ? Band.Low : Mid >= High ? Band.Mid : Band.High;
+    public Band StrongestBand
+    {
+        get
+        {
+            if (Low >= Mid && Low >= High)
+            {
+                return Band.Low;
+            }
+
+            return Mid >= High ? Band.Mid : Band.High;
+        }
+    }
 
     /// <summary>Spectral balance from zero at low through one at high; zero at silence.</summary>
     public float Centroid
@@ -82,6 +93,9 @@ public readonly struct LevelsValues
 
 public partial class BeatManager
 {
+    /// <summary>Peak fall time used when no usable musical tempo is available.</summary>
+    private const float StandalonePeakDrainSeconds = 0.5f;
+
     /// <summary>Attack time constant in seconds for rising smoothed levels.</summary>
     [SerializeField]
     private float levelsAttackSeconds = 0.02f;
@@ -95,9 +109,9 @@ public partial class BeatManager
     /// <summary>Latest tempo-draining peak state.</summary>
     private LevelBands peakLevels;
     /// <summary>Last clock sample used by both shaping algorithms.</summary>
-    private float lastSmoothingTime;
+    private float lastShapingTime;
     /// <summary>Whether a prior shaping clock sample exists.</summary>
-    private bool hasSmoothingClock;
+    private bool hasShapingClock;
     /// <summary>Whether shaping state has been initialized from an input sample.</summary>
     private bool hasLevelShaping;
 
@@ -107,9 +121,9 @@ public partial class BeatManager
     /// <summary>Advances Smoothed and Peak from the current normalized wire levels.</summary>
     private void UpdateLevelsShaping(float timeSeconds)
     {
-        var deltaSeconds = hasSmoothingClock ? Mathf.Max(0f, timeSeconds - lastSmoothingTime) : 0f;
-        lastSmoothingTime = timeSeconds;
-        hasSmoothingClock = true;
+        var deltaSeconds = hasShapingClock ? Mathf.Max(0f, timeSeconds - lastShapingTime) : 0f;
+        lastShapingTime = timeSeconds;
+        hasShapingClock = true;
 
         var normalized = ReadNormalizedLevels();
         if (!hasLevelShaping)
@@ -146,7 +160,7 @@ public partial class BeatManager
     private float PeakDrainBeatSeconds() =>
         IsSynced && wireSnapshot.beatAverageMs > 0
             ? wireSnapshot.beatAverageMs / 1000f
-            : 0.5f;
+            : StandalonePeakDrainSeconds;
 
     /// <summary>Moves one band through the configured attack or release follower.</summary>
     private float SmoothTowards(float current, float target, float deltaSeconds)

--- a/Assets/core/Rhythm/OffbeatsValues.cs
+++ b/Assets/core/Rhythm/OffbeatsValues.cs
@@ -28,7 +28,7 @@ public partial class BeatManager
     /// <summary>Latest derived milliseconds-until values in count order.</summary>
     private int[] offBeatsCountMs = CreateUnavailableCountdowns();
     /// <summary>Latest derived active-window values in count order.</summary>
-    private bool[] offBeats = new bool[BeatSlotCount];
+    private bool[] offBeatWindows = new bool[BeatSlotCount];
     /// <summary>Latest derived continuous Offbeat pulse.</summary>
     private float offBeatPulse;
 
@@ -37,29 +37,29 @@ public partial class BeatManager
 
     /// <summary>Captures the settled derived Offbeat lanes for public reading.</summary>
     private OffbeatsValues CaptureOffbeats() =>
-        new(new BeatCountLanes(offBeatsCountMs, offBeats));
+        new(new BeatCountLanes(offBeatsCountMs, offBeatWindows));
 
     /// <summary>Derives the four Offbeat countdowns, windows, and pulse from the measured On Beats.</summary>
     private void DeriveOffBeats()
     {
-        var counts = CreateUnavailableCountdowns();
-        var active = new bool[BeatSlotCount];
+        var countdowns = CreateUnavailableCountdowns();
+        var activeWindows = new bool[BeatSlotCount];
         offBeatPulse = 0f;
         var snapshot = wireSnapshot;
         if (!IsSynced || snapshot.beatAverageMs <= 0 || snapshot.beatsCountMs == null ||
             snapshot.beatsCountMs.Length < BeatSlotCount)
         {
-            offBeatsCountMs = counts;
-            offBeats = active;
+            offBeatsCountMs = countdowns;
+            offBeatWindows = activeWindows;
             return;
         }
 
         var activeWindowMs = snapshot.beatAverageMs * 0.25f;
         var measureMs = snapshot.beatAverageMs * (float)BeatSlotCount;
         var nearestOffBeatMs = float.MaxValue;
-        for (var slot = 0; slot < counts.Length; slot++)
+        for (var slot = 0; slot < countdowns.Length; slot++)
         {
-            var nextBeatSlot = (slot + 1) % counts.Length;
+            var nextBeatSlot = (slot + 1) % countdowns.Length;
             float startBeatMs = snapshot.beatsCountMs[slot];
             float nextBeatMs = snapshot.beatsCountMs[nextBeatSlot];
             if (startBeatMs < 0 || nextBeatMs < 0)
@@ -83,19 +83,19 @@ public partial class BeatManager
 
             if (nextBeatMs > halfGapMs)
             {
-                counts[slot] = Mathf.RoundToInt(offBeatMs);
+                countdowns[slot] = Mathf.RoundToInt(offBeatMs);
                 continue;
             }
 
             var elapsedMs = halfGapMs - nextBeatMs;
             if (elapsedMs <= activeWindowMs)
             {
-                counts[slot] = 0;
-                active[slot] = true;
+                countdowns[slot] = 0;
+                activeWindows[slot] = true;
             }
             else
             {
-                counts[slot] = Mathf.RoundToInt(measureMs - elapsedMs);
+                countdowns[slot] = Mathf.RoundToInt(measureMs - elapsedMs);
             }
         }
 
@@ -107,7 +107,7 @@ public partial class BeatManager
                 Mathf.Clamp01(elapsedMs / snapshot.beatAverageMs));
         }
 
-        offBeatsCountMs = counts;
-        offBeats = active;
+        offBeatsCountMs = countdowns;
+        offBeatWindows = activeWindows;
     }
 }

--- a/Assets/core/Rhythm/PhraseValues.cs
+++ b/Assets/core/Rhythm/PhraseValues.cs
@@ -28,7 +28,7 @@ public readonly struct PhraseValues
     /// <summary>Total phrase length in beats.</summary>
     public int? LengthBeats { get; }
 
-    /// <summary>Whether the phrase length breaks the sender's sixteen-beat grid; false when unknown.</summary>
+    /// <summary>Whether the phrase length is not divisible by 16; false when unknown.</summary>
     public bool Irregular { get; }
 
     /// <summary>Derived 0..1 position through the phrase.</summary>

--- a/Assets/core/Rhythm/PlayersValues.cs
+++ b/Assets/core/Rhythm/PlayersValues.cs
@@ -212,11 +212,11 @@ public readonly struct PlayerValues
     /// <summary>This player's loop wire values, in the same shape as the on-air <see cref="BeatManager.Loop"/>.</summary>
     public LoopValues Loop { get; }
 
-    /// <summary>This player's sixteen-beat grid trust state; null when unavailable.</summary>
+    /// <summary>This player's phrase-relative timing-grid trust state; null when unavailable.</summary>
     public GridState? GridState { get; }
-    /// <summary>One-based beat within this player's sixteen-beat grid.</summary>
+    /// <summary>One-based position within this player's phrase-relative 16-position timing-grid cycle.</summary>
     public int? GridBeat { get; }
-    /// <summary>One-based bar within this player's four-bar grid.</summary>
+    /// <summary>One-based four-beat subdivision within this player's timing-grid cycle.</summary>
     public int? GridBar { get; }
 
     /// <summary>This player's assembled song structure.</summary>
@@ -267,14 +267,16 @@ public partial class BeatManager
     /// </remarks>
     private PlayersValues CapturePlayers()
     {
-        var wire = wireSnapshot.players;
-        var captured = new PlayerValues[RaveWireSnapshot.PlayerCount];
-        for (var i = 0; i < captured.Length; i++)
+        var wirePlayers = wireSnapshot.players;
+        var capturedPlayers = new PlayerValues[RaveWireSnapshot.PlayerCount];
+        for (var i = 0; i < capturedPlayers.Length; i++)
         {
-            var state = wire != null && i < wire.Length ? wire[i] : PlayerState.Unavailable;
-            captured[i] = CapturePlayer(i, state);
+            var state = wirePlayers != null && i < wirePlayers.Length
+                ? wirePlayers[i]
+                : PlayerState.Unavailable;
+            capturedPlayers[i] = CapturePlayer(i, state);
         }
-        return new PlayersValues(captured);
+        return new PlayersValues(capturedPlayers);
     }
 
     /// <summary>Translates one player's wire lanes into an immutable entry for slot <paramref name="slot"/>.</summary>
@@ -287,7 +289,21 @@ public partial class BeatManager
         var cursor = state.cursor;
         // Match the on-air grid capture: an unparseable state label makes the whole grid
         // unavailable — the state is the trust gate for beat and bar.
-        var hasGrid = TryParseGridState(grid.state, out var gridState);
+        var hasGridState = TryParseGridState(grid.state, out var gridState);
+        var loopValues = TranslateLoop(state.loopState);
+        var structureValues = new StructureValues(
+            structure.generation,
+            string.IsNullOrEmpty(structure.trackId) ? null : structure.trackId,
+            ParseStructureSource(structure.source),
+            NonNegativeOrNull(structure.totalBeats),
+            structure.phraseCount,
+            TranslatePhrases(slot, structure));
+        var cursorValues = new StructureCursorValues(
+            cursor.generation,
+            cursor.currentPhrase >= 1 ? cursor.currentPhrase : null,
+            cursor.beatInPhrase >= 1 ? cursor.beatInPhrase : null,
+            NonNegativeOrNull(cursor.beatsToNextPhrase));
+
         return new PlayerValues(
             slot + 1,
             clock.bpm > 0f ? clock.bpm : null,
@@ -301,22 +317,12 @@ public partial class BeatManager
             TriStateOrNull(transport.master),
             TriStateOrNull(transport.synced),
             TriStateTrue(transport.playing) && TriStateTrue(transport.onAir),
-            TranslateLoop(state.loopState),
-            hasGrid ? gridState : null,
-            hasGrid && grid.beat >= 1 ? grid.beat : null,
-            hasGrid && grid.bar >= 1 ? grid.bar : null,
-            new StructureValues(
-                structure.generation,
-                string.IsNullOrEmpty(structure.trackId) ? null : structure.trackId,
-                ParseStructureSource(structure.source),
-                NonNegativeOrNull(structure.totalBeats),
-                structure.phraseCount,
-                TranslatePhrases(slot, structure)),
-            new StructureCursorValues(
-                cursor.generation,
-                cursor.currentPhrase >= 1 ? cursor.currentPhrase : null,
-                cursor.beatInPhrase >= 1 ? cursor.beatInPhrase : null,
-                NonNegativeOrNull(cursor.beatsToNextPhrase)));
+            loopValues,
+            hasGridState ? gridState : null,
+            hasGridState && grid.beat >= 1 ? grid.beat : null,
+            hasGridState && grid.bar >= 1 ? grid.bar : null,
+            structureValues,
+            cursorValues);
     }
 
     /// <summary>Translates one player's wire phrase list, reusing the previous frame's translation when unchanged.</summary>
@@ -356,10 +362,10 @@ public partial class BeatManager
                 phrase.fillStartBeat >= 1 ? phrase.fillStartBeat : null,
                 phrase.dropLandingBeat >= 1 ? phrase.dropLandingBeat : null);
         }
-        var wrapped = new ReadOnlyCollection<StructurePhraseValues>(translated);
+        var readOnlyPhrases = new ReadOnlyCollection<StructurePhraseValues>(translated);
         playerPhrasesGeneration[slot] = structure.generation;
-        playerPhrasesCache[slot] = wrapped;
-        return wrapped;
+        playerPhrasesCache[slot] = readOnlyPhrases;
+        return readOnlyPhrases;
     }
 
     /// <summary>Translates the wire's closed lowercase phrase-type labels; anything else is Unknown.</summary>
@@ -398,15 +404,15 @@ public partial class BeatManager
     /// </remarks>
     private void ClearPlayersToNoBeat()
     {
-        var players = wireSnapshot.players;
-        if (players == null)
+        var wirePlayers = wireSnapshot.players;
+        if (wirePlayers == null)
         {
             return;
         }
 
-        for (var i = 0; i < players.Length; i++)
+        for (var i = 0; i < wirePlayers.Length; i++)
         {
-            players[i] = PlayerState.Unavailable;
+            wirePlayers[i] = PlayerState.Unavailable;
         }
     }
 }

--- a/Assets/core/Rhythm/PulsesValues.cs
+++ b/Assets/core/Rhythm/PulsesValues.cs
@@ -7,17 +7,22 @@ using UnityEngine;
 /// <summary>Immutable wire and tempo-derived pulse values captured for one BeatManager update.</summary>
 public readonly struct PulsesValues
 {
-    /// <summary>Whether duration-based pulse reads are available.</summary>
-    private readonly bool synced;
+    /// <summary>Whether the captured frame has a usable running one-through-four clock.</summary>
+    private readonly bool hasUsableClock;
     /// <summary>Captured 0..1 position through the current bar.</summary>
     private readonly float barProgress;
 
     /// <summary>Captures the pulse values and duration clock for one update.</summary>
-    internal PulsesValues(bool live, bool synced, float beat, float offBeat, float barProgress)
+    internal PulsesValues(
+        bool hasLiveWire,
+        bool hasUsableClock,
+        float beat,
+        float offBeat,
+        float barProgress)
     {
-        this.synced = synced;
-        Beat = live ? beat : 0f;
-        OffBeat = synced ? offBeat : 0f;
+        this.hasUsableClock = hasUsableClock;
+        Beat = hasLiveWire ? beat : 0f;
+        OffBeat = hasUsableClock ? offBeat : 0f;
         this.barProgress = barProgress;
     }
 
@@ -30,14 +35,14 @@ public readonly struct PulsesValues
     /// <summary>Returns a tempo-based 1→0 pulse for every selected musical duration; rests at zero without synchronization.</summary>
     public float Every(Duration duration)
     {
-        var phase = synced ? DurationClock.Phase(barProgress, duration) : null;
+        var phase = hasUsableClock ? DurationClock.Phase(barProgress, duration) : null;
         return phase is { } value ? DurationClock.Pulse(value) : 0f;
     }
 
     /// <summary>Returns true for the first <paramref name="activeFor"/> fraction of every duration; false without synchronization.</summary>
     public bool On(Duration duration, float activeFor = 0.25f)
     {
-        var phase = synced ? DurationClock.Phase(barProgress, duration) : null;
+        var phase = hasUsableClock ? DurationClock.Phase(barProgress, duration) : null;
         return phase is { } value && value < Mathf.Clamp01(activeFor);
     }
 }
@@ -78,6 +83,11 @@ public partial class BeatManager
     /// <summary>Captures wire and derived pulse values for public reading.</summary>
     private PulsesValues CapturePulses()
     {
-        return new PulsesValues(liveBeatActive, IsSynced, wireSnapshot.beatPulse, offBeatPulse, BarPhase);
+        return new PulsesValues(
+            hasLiveWire: liveBeatActive,
+            hasUsableClock: IsSynced,
+            beat: wireSnapshot.beatPulse,
+            offBeat: offBeatPulse,
+            barProgress: BarPhase);
     }
 }


### PR DESCRIPTION
Behavior-preserving polish pass over `Assets/core/Rhythm/`, reviewed against `docs/osc-client-contract.md` and validated with Unity compile (0 warnings) and the full test suite (343/343 passing).

## Changes

- Delete the `DeriveBeatState` pass-through; `Update` calls `DeriveOffBeats` directly.
- Rename `ClearPhraseAndLevelState` → `ClearOnAirAnalysisState`, `offBeats` → `offBeatWindows`, and the shaping clock fields to `lastShapingTime`/`hasShapingClock`. No stale references remain; none of the renamed fields are serialized.
- Name the standalone peak drain constant; stop borrowing `UnavailableMs` for the bpm sentinel (same `-1` value).
- Rename `PulsesValues` constructor parameters to `hasLiveWire`/`hasUsableClock` and pass them as named arguments.
- Hoist `CapturePlayer`'s loop/structure/cursor translations into named locals.
- Correct grid and phrase doc comments to the contract's phrase-relative 16-position timing-grid model (the old "sixteen-beat grid / four-bar grid" wording was the inaccurate side).

## Validation

- Serena/LSP diagnostics clean on all touched files.
- `scripts/unity-compile.sh`: 0 C# warnings.
- `scripts/unity-tests.sh`: 343/343 passed, including `BeatManagerDataSurfaceTests` pinning the public rhythm surface.

https://claude.ai/code/session_01S6L6iyhAhyFhpEVixbM2as
